### PR TITLE
Replacing application schematic with application scopes in intro and overview docs

### DIFF
--- a/1.purpose_and_goals.md
+++ b/1.purpose_and_goals.md
@@ -8,11 +8,13 @@ This specification provides a description of such applications, where the descri
 
 This open specification defines:
 
-- __Component schematics__, which may be used by developers to declare the operational characteristics of the code they deliver _in infrastructure neutral terms_.
-- __Application schematics__ based on the __Hydra__ application model for distributed, "cloud native" applications composed of such Hydra components.
-- __Operational configuration__ for configuring an instance of an application.
+- __Component schematics__, where developers to declare the operational characteristics of the code they deliver _in infrastructure neutral terms_.
+- __Application scopes__, a way to group components into loosely couple
+applications with common characteristics.
+- __Traits__ for assigning operational features to instances of components.
+- __Operational configuration__, defines a deployment of components, their traits, and application scopes.
 - __Workload types and configurations__, which describe the underlying runtime for a particular workload, as well as exposing per-application configuration.
-- __Traits__ for assigning operational features to instances of an application.
+
 
 Additional goals of the specification are to:
 
@@ -31,7 +33,7 @@ Non-goals include:
 
 ## Design Principles
 
-The Hydra Application Model follows a few design principles that ensure the clarity, richness, and extensibility of the specification.
+The application model follows a few design principles that ensure the clarity, richness, and extensibility of the specification.
 
 ### Separation of Concerns
 
@@ -59,9 +61,7 @@ The spec as a whole is designed to provide application "distributions" where the
 
 ## Application Models Are Not Programming Models
 
-There is a clear distinction between an _application model_ and a _programing model_. An application model represents an attempt to capture the characteristics of a _distributed application_ or a _cloud native application_. It does so by revealing how the constituent parts of a distributed application are sewn together to create a functional whole.
-
-An application model describes the composition of an application and the topology of its components. It is not concerned with how each component is implemented (language, design patterns, etc).
+There is a clear distinction between an _application model_ and a _programming model_. An application model describes the composition of an application and the topology of its components. It is not concerned with how each component is implemented (language, design patterns, etc).
 
 On the other hand, a _programming model_ describes how an individual piece of software is composed. It is used by a developer to implement application components. Hydra offers an application model that does not have any requirements of a programming model.
 

--- a/2.overview_and_terminology.md
+++ b/2.overview_and_terminology.md
@@ -20,46 +20,15 @@ This specification proposes a model that defines cloud native applications as fo
 
 > A cloud native application is a collection of interrelated, but discrete _components_ (services, tasks, workers) that, when coupled with configuration and instantiated in a suitable runtime, together accomplish a unified functional purpose.
 
-There are two major constituent parts when defining an application:
+The application model defines the following:
 
-- A _component schematic_ represents a runnable unit, together with a description (schematic).
-- An _application schematic_ represents an assembly of components such that together they perform as a functional whole.
+ - _Components_ represents a runnable unit, together with a description (schematic).
+ - _Workload types_ identify the different workloads that a component can execute.
+ - _Traits_ are overlays that augment a component with additional operations-specific features. Traits represent operator concerns, not developer concerns.
+ - _Application scopes_ represent application boundaries by grouping components with common properties or dependencies.
+ - An _operational configuration_ describes a set of component instances, their traits, and the application scopes in which they are placed, combined with configuration parameters and metadata.
 
-On the operational side, there are additional constituent parts:
-
-- _Workload types_ which identify the different workloads that a component can execute.
-- A _trait_ is an overlay that augments a component with additional operations-specific features. Traits represent operator concerns, not developer concerns. 
-- An _operational configuration_ describes how an application is to be run, supplying configuration data and metadata. 
-
-An _application instance_ is a running application. Combining an operational configuration with an application schematic (model) creates an instance.
-
-A schematic is a static representation of a resource that declares the structure, requirements, and configurable parameters for that resource.
-
-## Terminology
-
-The following terms are used throughout this specification.
-
-### Component Schematics
- 
-__Component schematics__ permit __developers__ to declare the operational characteristics of the code they deliver _in infrastructure neutral terms_. Apart from not burdening developers with infrastructural concerns, this frees operators and runtimes to meet a component's infrastructural needs in whatever opinionated manner they see fit.
-
-A component schematic is composed of the following pieces of information:
-
-- A Workload Type: A declaration about what kind of runtime this component relies upon. (The platform will select a runtime that is capable of running this workload type.)
-- Metadata: Information _about_ the component, primarily directed toward the user
-- Resource requirements: The additional minimum needs that must be satisfied in order for the component to be executed. For example, minimum memory, CPU, and filesystem mounts
-- Parameters: The parameters that can be adjusted for specific runtime configuration
-- Containers: A list of the runnable pieces (OCI images, functions, etc.) necessary for this component. A component has at least one of these
-
-### Application Schematics / Hydra Applications
-
-__Application schematics__ describe an application as an assembly of components, together with application-wide parameterization and metadata. Application schematics based on the Hydra application model permit __application composers__ to define "cloud native" applications as an assembly of discrete component schematics. The present specification does not define workflow or tooling for producing application schematics.
-
-An application schematic is composed of the following parts:
-
-- Components: A manifest of the components that are part of this application
-- Metadata: Information about the application
-- Parameters: Configurable parameters on the application (as a whole). These parameters may be injected into components
+Thus, an _application_ is a collection of _components_ with a set of operational traits and scoped together into one or more application boundaries. 
 
 ## Group, Version, and Kind
 
@@ -138,6 +107,24 @@ Proxy.local.dev # allowed but discouraged
 ```
 
 This form is not accepted as an alternative for the fully qualified version. It is only accepted in cases where it is explicitly stated by the specification that this form is accepted.
+
+
+## Terminology
+
+The following terms are used throughout this specification.
+
+### Component Schematics
+ 
+__Component schematics__ permit __developers__ to declare the operational characteristics of the code they deliver _in infrastructure neutral terms_. Apart from not burdening developers with infrastructural concerns, this frees operators and runtimes to meet a component's infrastructural needs in whatever opinionated manner they see fit.
+
+A component schematic is composed of the following pieces of information:
+
+- A Workload Type: A declaration about what kind of runtime this component relies upon. (The platform will select a runtime that is capable of running this workload type.)
+- Metadata: Information _about_ the component, primarily directed toward the user
+- Resource requirements: The additional minimum needs that must be satisfied in order for the component to be executed. For example, minimum memory, CPU, and filesystem mounts
+- Parameters: The parameters that can be adjusted for specific runtime configuration
+- Containers: A list of the runnable pieces (OCI images, functions, etc.) necessary for this component. A component has at least one of these
+
 
 
 ### Workloads and Workload Types


### PR DESCRIPTION
Content update only, no changes to the actual spec.