### PR TITLE
Add variables and properties in config

### DIFF
--- a/6.operational_configuration.md
+++ b/6.operational_configuration.md
@@ -146,7 +146,7 @@ Values supplied to parameters that are used to override the parameters exposed b
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
 | `name` | `string` | Y | | The name of the component parameter to provide a value for. |
-| `value` | `string` | N || The environment variable value. If this is not supplied, `fromParam` must be supplied |
+| `value` | `string` | N || The value of this parameter. |
 
 The `value` field _allows_ use of the `[fromVariable(VARNAME)]` function.
 
@@ -380,4 +380,6 @@ spec:
 
 This example now shows a complete application instance composed of two components, an ingress trait, and a network scope with parameters exposed to an application operator to customize the application's domain name, the network to deploy it to, and a custom message for the application to display.
 
-Next Part: [Workload Types](7.workload_types.md)
+| Tables        | Next           | 
+| ------------- |-------------| 
+| [5. Traits](5.traits.md)       | [7. Workload Types](7.workload_types.md) |


### PR DESCRIPTION
Following up on a call with @BharatNarasimman and @vturecek, this is our more streamlined way of handling value substitution and complex properties.

We will still need to specify how schemata are defined in traits and scopes, but that can be a follow-up PR.