### PR TITLE
Add replicaCount to ops config

### DIFF
--- a/6.operational_configuration.md
+++ b/6.operational_configuration.md
@@ -117,7 +117,10 @@ This section defines the instances of components to create with this operational
 | `componentName` | `string` | Y | | The name of the component to create an instance of. |
 | `instanceName` | `string` | Y | | The name of the instance of this component. |
 | `parameterValues` | [`[]ParameterValue`](#parameterValue) | N | | Overrides of parameters that are exposed by the application scope type defined in `type`. |
+| `replicaCount` | `int` | N | 1 | The replica count (for any type that supports replication). |
 | `traits` | [`[]Trait`](#trait) | N | | Specifies the traits to attach to this component instance. |
+
+Note that `replicaCount` MUST be ignored for any workload type that does not support it, such as Singletons.
 
 ### Trait
 The scope section defines a instance of a trait and its parameter overrides.
@@ -172,6 +175,7 @@ spec:
   components:
     - componentName: my-web-app-component
       instanceName: my-app-frontent
+      replicaCount: REPLICA_COUNT
       parameterValues:
         - name: PARAMETER_NAME
           value: SUPPLIED_VALUE
@@ -264,6 +268,7 @@ spec:
   components:
     componentName: frontend
     instanceName: web-front-end
+    replicaCount: 3
     parameterValues:
       - name: message
         value: "[fromVariable(message)]"


### PR DESCRIPTION
Added replica count per #9. In this draft, I stated that if it is set on a component type that does not support replica counts, the field is _ignored_. We could change to an error.

/cc @macolso 