### PR TITLE
Update 3.component_model.md

### DIFF
--- a/3.component_model.md
+++ b/3.component_model.md
@@ -370,11 +370,11 @@ spec:
       fromParam: 'backend-address'
     livenessProbe:
       httpGet:
-        port: http
+        port: 8080
         path: /healthz
     readinessProbe:
       httpGet:
-        port: http
+        port: 8080
         path: /healthz
 ```
 


### PR DESCRIPTION
**minor typo fix**: updated the componentSchematic example's liveness/readiness probe so that it was passed the correct port parameter according to table above