### PR TITLE
Updating the spec to use Resources.Volumes instead of Resources.Paths.

### DIFF
--- a/3.component_model.md
+++ b/3.component_model.md
@@ -240,13 +240,15 @@ The format of the path is specific to the operating system of the consuming serv
 | `sharingPolicy` | `string` | N | `Exclusive` | The sharing policy for the mount, indicating if it is expected to be shared or not. Allowed values are `Exclusive` and `Shared`. |
 | `disk` | [`Disk`](#disk) | N |  | Specifies the attributes of the underneath disk resources required by the volume. |
 
+See the Units section above for valid values.
+
 #### Disk
 
 The disk specifies the attributes of the disk used by the volume. It describes information such as minimum disk size and the disk is ephemeral or not. Ephemeral disk indicates the component requires minimum disk size on the node to run it. For example, image processing component may require a larger cache on the node to run could use ephemeral disk. When ephemeral disk is set to false, it indicates external disk will be used.
 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
-| `required` | `string` | Y |  | The minimum disk size in MB required for running this container. The value should be a positive integer, greater than zero. |
+| `required` | `string` | Y |  | The minimum disk size required for running this container. The value should be a positive integer, greater than zero. |
 | `ephemeral` | `boolean` | N | | Specifies whether external disk needs to be mounted or not. |
 
 See the Units section above for valid values.


### PR DESCRIPTION
Updating Resouces.Paths in the component spec to Resources.Volumes and add disk section to the Volume type containing the required size and ephemeral or not.


Issue: https://github.com/microsoft/hydra-spec/issues/15