### PR TITLE
About some attributes

### DIFF
--- a/4.application_scopes.md
+++ b/4.application_scopes.md
@@ -78,6 +78,7 @@ The spec defines the constituent parts of a scope.
 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
+| `type` | `string` | Y | | Determines type of the application scope. |
 | `allowComponentOverlap` | `bool` | Y | | Determines whether a component is allowed to be in multiple instances of this scope type simultaneously. When false, the runtime implementation MUST produce an error and stop deployment if an attempt is made to place a component into more than one instance of this scope type simultaneously. |
 | `parameters` | [`[]Parameter`](#parameter) | N | | The scope's configuration options. |
 
@@ -112,13 +113,14 @@ The network scope may also be queried by traffic management traits to determine 
 #### Example
 This is an example of a network scope definition. 
 ```yaml
-schemaVersion: core.hydra.io/v1alpha1
+apiVersion: core.hydra.io/v1alpha1
 kind: ApplicationScope
 metadata:
   name: myNetworkScope
   description: The production configuration for Corp CMS
 spec:
   type: core.hydra.io/v1.NetworkScope
+  allowComponentOverlap: false
   parameters:
     - name: networkName     
       description: The name of the network
@@ -142,13 +144,14 @@ The health scope on its own does not take any action based on health status. It 
 #### Example
 This is an example of a health scope definition. 
 ```yaml
-schemaVersion: core.hydra.io/v1alpha1
+apiVersion: core.hydra.io/v1alpha1
 kind: ApplicationScope
 metadata:
   name: myHealthScope
   description: The production configuration for Corp CMS
 spec:
   type: core.hydra.io/v1.HealthScope
+  allowComponentOverlap: true
   parameters:
     - name: healthThresholdPercentage     
       description: The % of healthy components required to upgrade scope
@@ -176,13 +179,14 @@ The resource quota scope sets resource quotas on a group of components. Resource
 #### Example
 This is an example of a resource quota scope definition. 
 ```yaml
-schemaVersion: core.hydra.io/v1alpha1
-kind: Scope
+apiVersion: core.hydra.io/v1alpha1
+kind: ApplicationScope
 metadata:
   name: myResourceQuotas
   description: The production configuration for Corp CMS
 spec:
   type: core.hydra.io/v1.ResourceQuotaScope
+  allowComponentOverlap: false
   parameters:
      - name: CPU     
       description: maximum CPU to be consumed by this scope
@@ -200,13 +204,14 @@ The identity scope uses an external identity provider to supply
 #### Example
 This is an example of a identity scope definition. 
 ```yaml
-schemaVersion: core.hydra.io/v1alpha1
-kind: Scope
+apiVersion: core.hydra.io/v1alpha1
+kind: ApplicationScope
 metadata:
   name: myResourceQuotas
   description: The production configuration for Corp CMS
 spec:
   type: core.hydra.io/v1.IdentityScope
+  allowComponentOverlap: true
   parameters:
      - name: IdentityProvider     
       description: the provider of identity for the scope


### PR DESCRIPTION
1. Top-Level Attribute is called apiVersion but the examples call schemaVersion
2. Spec is missing type for the ApplicationScope (examples have it)
3. Examples are missing required attribute allowComponentOverlap