### PR TITLE
Fix yaml examples

### DIFF
--- a/6.operational_configuration.md
+++ b/6.operational_configuration.md
@@ -297,7 +297,7 @@ Here is how the previous operational configuration looks with an `ingress` trait
 
 ```yaml
 apiVersion: core.hydra.io/v1alpha1
-kind: Configuration
+kind: OperationalConfiguration
 metadata:
     name: custom-single-app
     description: Customized version of single-app
@@ -337,7 +337,7 @@ In this example, a network scope is defined and attached to an SDN. Both compone
 
 ```yaml
 apiVersion: core.hydra.io/v1alpha1
-kind: Configuration
+kind: OperationalConfiguration
 metadata:
     name: custom-single-app
     description: Customized version of single-app


### PR DESCRIPTION
I believe `Configuration` should be `OperationalConfiguration`.  (not sure operational configuration is the best naming though :P )