### PR TITLE
Add a 'migrateable' flag on a component

### DIFF
--- a/3.component_model.md
+++ b/3.component_model.md
@@ -71,6 +71,7 @@ The spec defines the constituent parts of a component.
 | `arch` | `string` | N | `amd64` | The CPU architecture required to host (all of) the component's containers (since containers share physical hardware with the underlying host). Possible values include:<ul><li>i386</li><li>amd64</li><li>arm</li><li>arm64</li></ul> |
 | `containers` | [`[]Container`](#container) | N | | The OCI container(s) that implement the component. |
 | `workloadSettings` | `[]WorkloadSettting` | N | | Declaration of non-container settings that should be passed to the workload runtime|
+| `migratable` | `boolean` | N | `true` | Indicates whether a component can be migrated. A `false` value indicates that a runtime must destroy and recreate this component on an "upgrade"-like request. | 
 
 ### Parameter
 


### PR DESCRIPTION
See comments on #12.

I am not totally sure this is ready for merge. We might need to describe a little more fully what we mean by `migrateable`. In this case, I just indicated that if this flag is `false`, the workload(s) attached to this component instance must be destroyed and recreated.