### PR TITLE
Add 'private' flag to parameter.

### DIFF
--- a/3.component_model.md
+++ b/3.component_model.md
@@ -83,6 +83,7 @@ The Parameters section defines all of the configurable parameters for this compo
 | `type` | `string` | Y | | The parameter's type. One of `boolean`, `number`, `string`, or `null` as defined in [the JSON specification](https://tools.ietf.org/html/rfc7159) and the [JSON Schema Validation spec](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6) |
 | `required` | `boolean` | N |`false` | Whether a value _must_ be provided for the parameter. |
 | `default` | type indicated by `type` field | N | | The parameter's default value. |
+| `private` | `boolean` | N | `false` | Indicates whether a value should be redacted out of any user-facing interface. |
 
 ### Workload Types
 


### PR DESCRIPTION
This would make it possible for user agents to redact values taht should not be shown in places like log files or user dialogs.

Closes #29