### PR TITLE
clarify what we mean by workloads

### DIFF
--- a/3.component_model.md
+++ b/3.component_model.md
@@ -88,31 +88,14 @@ The Parameters section defines all of the configurable parameters for this compo
 
 A _workload type_ is an indicator to the runtime as to how it should execute the given workload. In other words, it provides a single field by which the developer can indicate to the runtime how the developer intends for this component to be executed.
 
-Workloads are named using a simple convention: `GROUP/VERSION.KIND`, where `GROUP` is a uniquely named service collection, `VERSION` is an API version, and `KIND` is a group-unique name of a service. Examples:
+Workloads are named using a simple convention: `GROUP/VERSION.KIND`, where `GROUP` is a uniquely named service collection, `VERSION` is an API version, and `KIND` is a group-unique name of a service.
+
+Examples:
 
 - `core.hydra.io/v1alpha1.Singleton`: The group is `core.hydra`, meaning it is built-in. The version indicates that this is still an alpha version (`v1alpha1`). The kind is `Singleton`. This means the core singleton runtime must be used for this component.
 - `azure.com/v1.Function`: The group is `azure.com` (which is a vendor-specific implementation, and may not be present on all runtimes). The version is `v1`, which marks this as stable. The kind is `Function`, whose runtime implementation is the Azure Functions offering.
 - `streams.hydra.io/v1beta2.Kafka`: The group is `streams.hydra.io`, a hypothetical location where certain vendor-neutral extensions may exist. Version is `v1beta2`, indicating that it is moving toward stability. And the kind is `Kafka`.
 - `caching.hydra.io/v2.Redis`: The group is `caching.hydra.io`, version is `v2`, and the kind is `Redis`. This describes an implementation of a Redis cache.
-
-This table provides an example of how extended Hydra services like the last two might have multiple implementations:
-
-3rd-party software | possible workload type | Azure managed service backing 
---|--|--
-Kafka            | streams.Kafka                 | EventHubs 
-Cassandra        | data.hydra.io/v1.Cassandra    | CosmosDB
-MongoDB          | data.hydra.io/v1.MongoDB      | CosmosDB
-PostgreSQL       | data.hydra.io/v1.PostgreSQL   | Azure Databases for PostgreSQL
-MySQL            | data.hydra.io/v1.MySQL        | Azure Databases for MySQL
-MariaDB          | data.hydra.io/v1.MariaDB      | Azure Databases for MariaDB
-SQL              | data.hydra.io/v1.SQL          | Azure SQL DB
-Apache Gremlin   | graph.hydra.io/v1.Gremlin     | CosmosDB
-Apache TinkerPop | graph.hydra.io/v1.TinkerPop   | CosmosDB
-AMQP             | messaging.hydra.io/v1.AMQP    | ServiceBus (RabbitMQ in Kubernetes)
-SignalR          | messaging.hydra.io/v1.SignalR | Azure SignalR Service
-Redis            | caching.hydra.io/v1.Redis     | Azure Redis
-
-([Source](https://github.com/microsoft/hydra-spec/pull/123#issuecomment-491108730))
 
 > Group, Version, Kind is a [convention in Kubernetes](https://kubernetes.io/docs/reference/using-api/api-concepts/)
 
@@ -147,9 +130,28 @@ Core workload descriptions MUST include a `container` section in the component s
 
 #### Extended Workload Types
 
-Extended workload types are _optional per runtime_, meaning that each runtime may choose which extended workload types are supported. In this version of the spec, allowing user-defined extended workload types is _not supported_.
+Extended workload types are _per runtime_, meaning that each runtime may define its own extended workload types beyond this specification. In the present version of the spec, allowing user-defined extended workload types is _not supported_.
 
 Some workload types are specific to containers, a primary runtime target for the model. Other workload types may allow (or even require) non-component runtimes. For example, a workload type of `azure.com/v1.ContainerInstance` may _require_ that the containerized workload be run using the Azure Container Instances tool, while `azure.com/v1.Functions` may require that a particular non-containerized workload be executed using Azure Functions.
+
+The definition of _workloads_ that is assumed herein is inclusive: It allows hosted services to be considered workloads, along with containerized binaries or VMs. For that reason, it is possible (though not at all required) to model things such as caches, databases, event hubs, functions, and message queues as workloads. This table provides a non-normative example of how extended Hydra services like the last two might have multiple implementations:
+
+3rd-party software | possible workload type | Azure managed service backing 
+--|--|--
+Kafka            | streams.Kafka                 | EventHubs 
+Cassandra        | data.hydra.io/v1.Cassandra    | CosmosDB
+MongoDB          | data.hydra.io/v1.MongoDB      | CosmosDB
+PostgreSQL       | data.hydra.io/v1.PostgreSQL   | Azure Databases for PostgreSQL
+MySQL            | data.hydra.io/v1.MySQL        | Azure Databases for MySQL
+MariaDB          | data.hydra.io/v1.MariaDB      | Azure Databases for MariaDB
+SQL              | data.hydra.io/v1.SQL          | Azure SQL DB
+Apache Gremlin   | graph.hydra.io/v1.Gremlin     | CosmosDB
+Apache TinkerPop | graph.hydra.io/v1.TinkerPop   | CosmosDB
+AMQP             | messaging.hydra.io/v1.AMQP    | ServiceBus (RabbitMQ in Kubernetes)
+SignalR          | messaging.hydra.io/v1.SignalR | Azure SignalR Service
+Redis            | caching.hydra.io/v1.Redis     | Azure Redis
+
+([Source](https://github.com/microsoft/hydra-spec/pull/123#issuecomment-491108730))
 
 Extended workload types MAY use the `containers` section of the component schematic, or MAY omit it. Extended workload types MAY use or omit the `workloadSettings` list in the component schematic. The purpose of the `workloadSetting` list is to provide authors of extended workload types with a location for specifying the configuration of that types.
 


### PR DESCRIPTION
The wording around extended workload types was very confusing. I tried to clear up the idea.

Just as a quick note of clarification: Defining extended workload types in the core spec, and then allowing them to be optionally implemented is against the goal of the specification. If the specification is supposed to make it possible that _any Hydra-compliant package_ can run on _any compliant runtime_, then optional parts of the specification render that goal moot.

To that end, optional parts of the spec, like common traits or extended workload types, should be written up _separately_ and stored in another to-be-determined place (maybe even in a clearly delineated subdirectory of this project).

Closes #22 
