### PR TITLE
trait: add `type` to spec

### DIFF
--- a/5.traits.md
+++ b/5.traits.md
@@ -26,7 +26,7 @@ The top-level attributes of a trait define its metadata, version, kind, and spec
 |-----------|------|----------|---------------|-------------|
 | `apiVersion` | `string` | Y || The specific version of the specification in use. At present only `core.hydra.io/v1alpha1` is defined. |
 | `kind` | `string` | Y || The string `Trait` |
-| `metadata` | `[]Metadata(#metadata)` | Y | | Trait metadata. |
+| `metadata` | `Metadata(#metadata)` | Y | | Trait metadata. |
 | `spec`| [`Spec`](#spec) | Y || A container for exposing trait attributes. |
 
 #### Metadata
@@ -47,6 +47,7 @@ The specification defines two major things: The list of workload types to which 
 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
+| `type` | string | Y | | Determines type of the Trait. |
 | `appliesTo` | `[]string` | N | `["*"]` | The list of workload types that this trait applies to. `"*"` means _any workload type_ |
 | `parameters` | [`[]Parameter`](#parameter) | N | | The component's configuration options. |
 
@@ -67,12 +68,14 @@ The parameters that this trait exposes to operators.
 This is an example of a trait definition that manually scales replicable services or replicable tasks:
 
 ```yaml
-apiVersion: extentsion.hydra.io/v1alpha1
+apiVersion: core.hydra.io/v1alpha1
+kind: Trait
 metadata:
     name: manualscaler
     version: v1.0.0
     description: Allow operator to manually scale a service
 spec:
+    type: example.hydra.io/v1alpha1.ManualScaler
     appliesTo:
         - replicableService
         - replicableTask
@@ -91,11 +94,13 @@ This is an example trait definition that applies an autoscaler to scalable workl
 
 ```yaml
 apiVersion: core.hydra.io/v1alpha1
+kind: Trait
 metadata:
     name: autoscaler
     version: v1.0.0
     description: Provide autoscaler support
 spec:
+    type: example.hydra.io/v1alpha1.AutoScaler
     appliesTo:
         - replicableService
         - replicableTask
@@ -157,6 +162,7 @@ kind: Trait
 metadata:
   name: SSL      # The name of the trait
 spec:
+    type: example.hydra.io/v1alpha1.SSL
   # Which primitives can use this trait.
   appliesTo: [ ReplicatedService, SingletonService ]     
   parameters:      # The parameters that a trait user may supply
@@ -187,6 +193,7 @@ metadata:
     version: v1.0.0
     description: Provide A/B testing
 spec:
+    type: example.hydra.io/v1alpha1.ABTesting
     appliesTo:
         - replicatedService
     parameters:


### PR DESCRIPTION
Currently the example in OperationalConfiguration has type in Trait but no type definition in Trait.

Similar to Scope:
```yaml
apiVersion: core.hydra.io/v1alpha1
kind: ApplicationScope
metadata:
  name: myNetworkScope
spec:
  type: core.hydra.io/v1.NetworkScope
  ...
```