### PR TITLE
component: add cmd, args to container spec

### DIFF
--- a/3.component_model.md
+++ b/3.component_model.md
@@ -164,6 +164,8 @@ This section describes the runtime configuration necessary to run a containerize
 | `name` | `string` | Y | | The container's name. Must be unique per component. |
 | `image` | `string` | Y | | A path-like or URI-like representation of the location of an OCI image. Where applicable, this MAY be prefixed with a registry address, SHOULD be suffixed with a tag, and MUST be suffixed with a digest in [OCI format](https://github.com/opencontainers/image-spec/blob/master/descriptor.md#digests). The digest may be used to compute the integrity of the image. Valid examples:<ul><li>`krancour/foobar@sha256:72e996751fe42b2a0c1e6355730dc2751ccda50564fec929f76804a6365ef5ef`</li><li> `krancour/foobar:v1.0.0@sha256:72e996751fe42b2a0c1e6355730dc2751ccda50564fec929f76804a6365ef5ef`</li><li>`krancour.azurecr.io/foobar@sha256:72e996751fe42b2a0c1e6355730dc2751ccda50564fec929f76804a6365ef5ef`</li><li>`krancour.azurecr.io/foobar/v1.0.0@sha256:72e996751fe42b2a0c1e6355730dc2751ccda50564fec929f76804a6365ef5ef`</li></ul> |
 | `resources` | [`Resources`](#resources) | Y | | Resources required by the container. |
+| `cmd` | `[]string`| N | | Entrypoint array. |
+| `args` | `[]string`| N | | Arguments to the entrypoint. The container image's CMD is used if this is not provided. |
 | `env` | [`[]Env`](#env) | N | | Environment variables for the container. |
 | `ports` | [`[]Port`](#port) | N | | Ports exposed by the container. |
 | `livenessProbe` | [`HealthProbe`](#healthprobe) | N | | Instructions for assessing whether the container is alive. |


### PR DESCRIPTION
A user would want to reuse container images but set different command and/or arguments for the containers to run.