### PR TITLE
trait, opConfig: replace parameterValues with properties

### DIFF
--- a/5.traits.md
+++ b/5.traits.md
@@ -221,7 +221,7 @@ spec:
       traits:
         - name: app-ingress
           type: core.hydra.io/v1alpha1.Ingress
-          parameterValues:
+          properties:
             - name: host
               value: www.example.com
             - name: path

--- a/6.operational_configuration.md
+++ b/6.operational_configuration.md
@@ -116,7 +116,7 @@ This section defines the instances of components to create with this operational
 |-----------|------|----------|---------------|-------------|
 | `componentName` | `string` | Y | | The name of the component to create an instance of. |
 | `instanceName` | `string` | Y | | The name of the instance of this component. |
-| `parameterValues` | [`[]ParameterValue`](#parameterValue) | N | | Overrides of parameters that are exposed by the application scope type defined in `type`. |
+| `properties` | [`Properties`](#properties) | N | | The properties attached to this Component. |
 | `traits` | [`[]Trait`](#trait) | N | | Specifies the traits to attach to this component instance. |
 
 ### Trait
@@ -132,20 +132,15 @@ The scope section defines a instance of a trait and its parameter overrides.
 
 A properties object (for trait and scope configuration) is an object whose structure is determined by the trait or scope property schema. It may be a simple value, or it may be a complex object.
 
-Properties are validated against the schema appropriate for the trait or scope.
+Properties are validated against the schema appropriate for the trait, scope, or component.
 
 For example, if a trait defines a schema for properties that requires an array of integers with at least one member, the `properties` object is expected to be an array of integers with at least one member. During validation of the `properties` object, the trait's property schema will be applied.
 
 If no schema is supplied, a property will be passed to the trait runtime without structural validation. As long as it parses as YAML or JSON, it will be considered valid.
 
-Any string value in a `properties` object MAY contain a `[fromVariable(VARNAME)]` function call.
-
-### ParameterValue
-Values supplied to parameters that are used to override the parameters exposed by other types.
-
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
-| `name` | `string` | Y | | The name of the component parameter to provide a value for. |
+| `name` | `string` | Y | | The name of the parameter to provide a value for. |
 | `value` | `string` | N || The value of this parameter. |
 
 The `value` field _allows_ use of the `[fromVariable(VARNAME)]` function.
@@ -165,14 +160,13 @@ spec:
       value: SUPPLIED_VALUE
   scopes:
     - name: core.hydra.io/v1alpha1.Network
-      parameterValues:
+      properties:
         - name: PARAM_NAME
           value: SUPPLIED_VALUE
-          fromParam: NAME_OF_TOP_LEVEL_PARAM
   components:
     - componentName: my-web-app-component
       instanceName: my-app-frontent
-      parameterValues:
+      properties:
         - name: PARAMETER_NAME
           value: SUPPLIED_VALUE
         - name: ANOTHER_PARAMETER
@@ -264,7 +258,7 @@ spec:
   components:
     componentName: frontend
     instanceName: web-front-end
-    parameterValues:
+    properties:
       - name: message
         value: "[fromVariable(message)]"
 ```
@@ -310,7 +304,7 @@ spec:
   components:
     - componentName: frontend
       instanceName: web-front-end
-      parameterValues:
+      properties:
         - name: message
           value: "[fromVariable(message)]"
       traits:
@@ -358,7 +352,7 @@ spec:
   components:
     - componentName: frontend
       instanceName: web-front-end
-      parameterValues:
+      properties:
         - name: message
           value: "[fromVariable(networkName)]"
       traits:


### PR DESCRIPTION
It's very confusing to have two notions (parameterValues, properties) having the same (at least very similar) meanings.
It would benefit users a lot for a simple and combined notion.