### PR TITLE
Minor corrections on component_model.md

### DIFF
--- a/3.component_model.md
+++ b/3.component_model.md
@@ -344,7 +344,7 @@ as a `ReplicableService`. The username, password, and address of the backend
 component are configurable.
 
 ```yaml
-apiVersion: hydra/v1alpha
+apiVersion: core.hydra.io/v1alpha1
 kind: ComponentSchematic
 metadata:
   description: >
@@ -408,7 +408,7 @@ configurable. The component schematic also describes the file system location
 where the component persists end-user-defined configuration.
 
 ```yaml
-apiVersion: hydra/v1alpha
+apiVersion: core.hydra.io/v1alpha1
 kind: ComponentSchematic
 metadata:
   description: >
@@ -475,7 +475,7 @@ spec:
 Imagine a service runtime that checks out code from a Git repository and executes it as an Azure function. This service might be used as follows:
 
 ```yaml
-apiVersion: hydra/v1alpha
+apiVersion: core.hydra.io/v1alpha1
 kind: ComponentSchematic
 metadata:
   description: Extended workflow example


### PR DESCRIPTION
It should be "core.hydra.io/v1alpha1" consistently.