### PR TITLE
workload_types.md: minor fix

### DIFF
--- a/7.workload_types.md
+++ b/7.workload_types.md
@@ -10,7 +10,7 @@ These attributes provide top-level information about the workload type.
 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
-| `apiVersion` | `string` | Y || The specific version of the specification in use. The core types use `workloads.hydra.io/v1alpha1` |
+| `apiVersion` | `string` | Y || The specific version of the specification in use. The core types use `core.hydra.io/v1alpha1` |
 | `kind` | `string` | Y || The string `WorkloadType` |
 | `metadata` | `[]Metadata(#metadata)` | Y | | WorkloadType metadata. |
 | `spec`| [`Spec`](#spec) | Y || A container for exposing the workload type definition. |


### PR DESCRIPTION
I'm also wondering why workload use `settings` and others use `parameters`? 