### PR TITLE
Fix typo 'scoe' in section 4

### DIFF
--- a/4.application_scopes.md
+++ b/4.application_scopes.md
@@ -170,7 +170,7 @@ spec:
 
 ## Extended application scope type definitions
 The following extended scope types are available:
-- resource quota scoe
+- resource quota scope
 - identity scope
 
 ### Resource Quota scope


### PR DESCRIPTION
`scoe` -> `scope`.