### PR TITLE
Extended application should not use core.hydra.io/*

### DIFF
--- a/4.application_scopes.md
+++ b/4.application_scopes.md
@@ -185,7 +185,7 @@ metadata:
   name: myResourceQuotas
   description: The production configuration for Corp CMS
 spec:
-  type: core.hydra.io/v1.ResourceQuotaScope
+  type: resources.hydra.io/v1.ResourceQuotaScope
   allowComponentOverlap: false
   parameters:
      - name: CPU     
@@ -210,7 +210,7 @@ metadata:
   name: myResourceQuotas
   description: The production configuration for Corp CMS
 spec:
-  type: core.hydra.io/v1.IdentityScope
+  type: identity.hydra.io/v1.IdentityScope
   allowComponentOverlap: true
   parameters:
      - name: IdentityProvider     


### PR DESCRIPTION
Extended application should not use core.hydra.io/*

However, suggested namespaces are solely suggestions and open to suggestions.