### PR TITLE
updated metadata to match Kubernetes

### DIFF
--- a/3.component_model.md
+++ b/3.component_model.md
@@ -2,11 +2,11 @@
 
 This section defines the component model.
 
-Components describe functional units that may be instantiated in a grouping. For example, each microservice in an application is described as a component. The description itself is not an instance of that microservice, but a declaration of the operational capabilities of that microservice. [Section 6, Operational Configuration](6.operational_configuration.md) describes how components are grouped together and how instances of those components are then configured.
+Components describe functional units that may be instantiated as part of a larger distributed application. For example, each microservice in an application is described as a component. The description itself is not an instance of that microservice, but a declaration of the operational capabilities of that microservice. [Section 6, Operational Configuration](6.operational_configuration.md) describes how components are grouped together and how instances of those components are then configured.
 
 ## Component Schematics
 
-The role of a component schematic is to permit developers to declare, in infrastructure-neutral terms, the operational characteristics of a discrete unit of execution.
+The role of a component schematic is to permit developers to declare, in infrastructure-neutral format, the operational characteristics of a discrete unit of execution.
 
 For example, a single microservice may be modeled as a component.
 
@@ -91,8 +91,6 @@ If `version` is not supplied, the default version is assumed to be `0.1.0`, per 
 Example:
 
 ```yaml
-apiVersion: core.hydra.io/v1alpha1
-kind: Component
 metadata:
   name: alpine-task
   labels:


### PR DESCRIPTION
This re-organizes the metadata to be Kubernetes friendly. Otherwise, tooling strips out some of the metadata.

Also updated the text to be more explicit about what this section of the spec is for