### PR TITLE
Change sections 4-7 to reference one metadata definition

### DIFF
--- a/4.application_scopes.md
+++ b/4.application_scopes.md
@@ -63,14 +63,7 @@ The following attributes are common across all schemata defined in this document
 
 ### Metadata
 
-Metadata provides information about the contents of this object.
-
-| Attribute | Type | Required | Default Value | Description |
-|-----------|------|----------|---------------|-------------|
-| `name` | `string` | Y | | the name of the scope. |
-| `description` | `string` | Y | | A short description of the scope. |
-| `version` | `string` | Y | | A string defining the [semantic version](https://semver.org/) of the scope. |
-| `labels` | `map[string]string` | N | | A set of string key/value pairs used as arbitrary labels on this scope. | 
+Metadata provides information about the contents of this object.The metadata section is defined in [Section 3](3.component_model.md#metadata). 
 
 ### Spec
 

--- a/5.traits.md
+++ b/5.traits.md
@@ -6,7 +6,7 @@ A _trait_ is a discretionary runtime overlay that augments the workload type (`w
 
 An individual trait MAY be tied to specific workload types (or MAY apply to all workload types). A trait MAY declare which workload types it applies to. For example, an _autoscaler_ trait could apply to a workload type _replicable service_, but not to type _singleton_. The `autoscaler` trait itself MUST define that restriction if present.
 
-There is no mechanism for explicitly requiring a combination of traits. For example, a trait (`ssl`) cannot require that another trait (`ingress`) be applied to an object. However, _implementations_ of a trait SHOULD fail if one trait cannot fulfill its contract without the presence of another trait. A system MAY support a mechanism in which a trait (`sslIngress`) is opaquely backed by two separate trait implementations (`ssl` and `ingress`).
+There is no mechanism for explicitly requiring a combination of traits. For example, a trait (`ssl`) cannot specify that it requires that another trait (`ingress`) be applied to an object. However, _implementations_ of a trait SHOULD fail if one trait cannot fulfill its contract without the presence of another trait. A system MAY support a mechanism in which a trait (`sslIngress`) is opaquely backed by two separate trait implementations (`ssl` and `ingress`).
 
 Because components can specify multiple traits, an implementation MUST support the application of zero or more traits to a component. An implementation MUST produce an error and stop deployment if the requested traits cannot be fulfilled by the underlying runtime.
 
@@ -16,7 +16,7 @@ The specification does not set requirements about how simple or complicated a tr
 
 This section is normative because traits are an inspectable (and possibly shareable) part of the system. All traits MUST be representable in the following format.
 
-Traits are defined with schematics like components.
+Traits are defined with schematics like components. Implementations of the Hydra runtime SHOULD make all supported traits discoverable in the format explained below.
 
 #### Top-Level Attributes
 
@@ -31,15 +31,7 @@ The top-level attributes of a trait define its metadata, version, kind, and spec
 
 #### Metadata
 
-Metadata describes this trait.
-
-| Attribute | Type | Required | Default Value | Description |
-|-----------|------|----------|---------------|-------------|
-| `name` | `string` | Y | | The name of the trait |
-| `version` | `string` | Y | | The version of the trait |
-| `description` | `string` | Y | | A short description of the trait. |
-| `labels` | `map[string]string` | N | | A set of string key/value pairs used as arbitrary labels on this component. | 
-
+Metadata describes this trait. The metadata section is defined in [Section 3](3.component_model.md#metadata).
 
 #### Spec
 

--- a/6.operational_configuration.md
+++ b/6.operational_configuration.md
@@ -71,13 +71,7 @@ The top-level attributes of a operational configuration define its metadata, ver
 | `spec`| [`Spec`](#spec) | Y || A container for exposing operational configuration attributes. |
 
 ### Metadata
-Metadata describes this trait.
-
-| Attribute | Type | Required | Default Value | Description |
-|-----------|------|----------|---------------|-------------|
-| `name` | `string` | Y | | The name of the operational configuration |
-| `description` | `string` | Y | | A short description of the operational configuration. |
-| `labels` | `map[string]string` | N | | A set of string key/value pairs used as arbitrary labels on this component. | 
+Metadata describes this trait. The metadata section is defined in [Section 3](3.component_model.md#metadata).
 
 
 ### Spec

--- a/7.workload_types.md
+++ b/7.workload_types.md
@@ -17,13 +17,7 @@ These attributes provide top-level information about the workload type.
 
 #### Metadata
 
-The metadata describes this workload type.
-
-| Attribute | Type | Required | Default Value | Description |
-|-----------|------|----------|---------------|-------------|
-| `name` | `string` | Y || The complete un-versioned name of the workload type, of the form `singleton.core.hydra.io`. It is formed by adding the singular name to the group, separated by a dot (`.`) |
-| `version` | `string` | Y | | The version of the workload type (`v1alpha1`) |
-| `description` | `string` | Y | | A short description of the workload type. |
+The metadata describes this workload type. The metadata section is defined in [Section 3](3.component_model.md#metadata).
 
 #### Spec
 


### PR DESCRIPTION
I just noticed that every type redefines `metadata` even though it is supposed to be the same for every resource type. I just replaced the md description in sections 4-7 with a link to the metadata section in 3.