### PR TITLE
Added rules for instanceName

### DIFF
--- a/6.operational_configuration.md
+++ b/6.operational_configuration.md
@@ -113,6 +113,10 @@ This section defines the instances of components to create with this operational
 | `parameterValues` | [`[]ParameterValue`](#parameterValue) | N | | Overrides of parameters that are exposed by the application scope type defined in `type`. |
 | `traits` | [`[]Trait`](#trait) | N | | Specifies the traits to attach to this component instance. |
 
+In addition to being unique, the `instanceName` must follow these naming rules:
+
+> The instanceName segment is required and must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.
+
 ### Trait
 The scope section defines a instance of a trait and its parameter overrides.
 


### PR DESCRIPTION
As @vturecek and I noticed earlier today, the requirements for this field were not specified. This adds a careful definition of instanceName fields.