### PR TITLE
*: move description in metadata into annotations

### DIFF
--- a/3.component_model.md
+++ b/3.component_model.md
@@ -456,8 +456,11 @@ component are configurable.
 apiVersion: core.hydra.io/v1alpha1
 kind: ComponentSchematic
 metadata:
-  description: >
-  Sample component schematic that describes the administrative interface for our Twitter bot.
+  name: replciatedservice
+  annotations:
+    version: v1.0.0
+    description: >
+      Sample component schematic that describes the administrative interface for our Twitter bot.
 spec:
   workloadType: ReplicableService
   osType: linux
@@ -520,10 +523,13 @@ where the component persists end-user-defined configuration.
 apiVersion: core.hydra.io/v1alpha1
 kind: ComponentSchematic
 metadata:
-  description: >
-  Sample component schematic that describes the backend for our Twitter bot.
+  name: singletonservice
+  annotations:
+    version: v1.0.0
+    description: >
+      Sample component schematic that describes the backend for our Twitter bot.
 spec:
-  workloadType: core.hydra.io/v1.Singleton
+  workloadType: core.hydra.io/v1.SingletonService
   osType: linux
   parameters:
   - name: twitter-consumer-key
@@ -587,7 +593,10 @@ Imagine a service runtime that checks out code from a Git repository and execute
 apiVersion: core.hydra.io/v1alpha1
 kind: ComponentSchematic
 metadata:
-  description: Extended workflow example
+  name: azurefunction
+  annotations:
+    version: v1.0.0
+    description: "Extended workflow example"
 spec:
   workloadType: azure.com/v1.Function
   parameters:

--- a/4.application_scopes.md
+++ b/4.application_scopes.md
@@ -105,7 +105,9 @@ apiVersion: core.hydra.io/v1alpha1
 kind: ApplicationScope
 metadata:
   name: myNetworkScope
-  description: The production configuration for Corp CMS
+  annotations:
+    version: v1.0.0
+    description: "The production configuration for Corp CMS"
 spec:
   type: core.hydra.io/v1.NetworkScope
   allowComponentOverlap: false
@@ -136,7 +138,9 @@ apiVersion: core.hydra.io/v1alpha1
 kind: ApplicationScope
 metadata:
   name: myHealthScope
-  description: The production configuration for Corp CMS
+  annotations:
+    version: v1.0.0
+    description: "The production configuration for Corp CMS"
 spec:
   type: core.hydra.io/v1.HealthScope
   allowComponentOverlap: true
@@ -170,7 +174,9 @@ apiVersion: core.hydra.io/v1alpha1
 kind: ApplicationScope
 metadata:
   name: myResourceQuotas
-  description: The production configuration for Corp CMS
+  annotations:
+    version: v1.0.0
+    description: "The production configuration for Corp CMS"
 spec:
   type: resources.hydra.io/v1.ResourceQuotaScope
   allowComponentOverlap: false
@@ -194,8 +200,10 @@ This is an example of a identity scope definition.
 apiVersion: core.hydra.io/v1alpha1
 kind: ApplicationScope
 metadata:
-  name: myResourceQuotas
-  description: The production configuration for Corp CMS
+  name: myIdentityScope
+  annotations:
+    version: v1.0.0
+    description: "The production configuration for Corp CMS"
 spec:
   type: identity.hydra.io/v1.IdentityScope
   allowComponentOverlap: true

--- a/5.traits.md
+++ b/5.traits.md
@@ -112,7 +112,9 @@ apiVersion: core.hydra.io/v1alpha1
 kind: Trait
 metadata:
   name: ManualScaler
-  description: Allow operators to manually scale a workloads that allow multiple replicas.
+  annotations:
+    version: v1.0.0
+    description: "Allow operators to manually scale a workloads that allow multiple replicas."
 spec:
   appliesTo:
     - core.hydra.io/v1alpha1.Service
@@ -139,7 +141,9 @@ apiVersion: core.hydra.io/v1alpha1
 kind: OperationalConfiguration
 metadata:
   name: custom-single-app
-  description: Customized version of single-app
+  annotations:
+    version: v1.0.0
+    description: "Customized version of single-app"
 spec:
   variables:
   components:

--- a/6.operational_configuration.md
+++ b/6.operational_configuration.md
@@ -156,7 +156,9 @@ apiVersion: core.hydra.io/v1alpha1
 kind: OperationalConfiguration
 metadata:
   name: my-app-deployment
-  description: Description of this deployment
+  annotations:
+    version: v1.0.0
+    description: "Description of this deployment"
 spec:
   variables:
     - name: VAR_NAME
@@ -201,8 +203,9 @@ apiVersion: core.hydra.io/v1alpha1
 kind: Component
 metadata:
   name: frontend
-  version: "1.0.0"
-  description: A simple webserver
+  annotations:
+    version: v1.0.0
+    description: "A simple webserver"
 spec:
   workloadType: core.hydra.io/v1.Replicated
   parameters:
@@ -223,8 +226,9 @@ apiVersion: core.hydra.io/v1alpha1
 kind: Component
 metadata:
   name: backend
-  version: "1.0.0"
-  description: Cassandra database
+  annotations:
+    version: v1.0.0
+    description: "Cassandra database"
 spec:
   workloadType: data.hydra.io/v1.Cassandra
   parameters:
@@ -254,7 +258,9 @@ apiVersion: core.hydra.io/v1alpha1
 kind: OperationalConfiguration
 metadata:
   name: custom-single-app
-  description: Customized version of single-app
+  annotations:
+    version: v1.0.0
+    description: "Customized version of single-app"
 spec:
   variables:
     - name: message
@@ -297,8 +303,10 @@ Here is how the previous operational configuration looks with an `ingress` trait
 apiVersion: core.hydra.io/v1alpha1
 kind: OperationalConfiguration
 metadata:
-    name: custom-single-app
-    description: Customized version of single-app
+  name: custom-single-app
+  annotations:
+    version: v1.0.0
+    description: "Customized version of single-app"
 spec:
   variables:
     - name: message
@@ -337,8 +345,10 @@ In this example, a network scope is defined and attached to an SDN. Both compone
 apiVersion: core.hydra.io/v1alpha1
 kind: OperationalConfiguration
 metadata:
-    name: custom-single-app
-    description: Customized version of single-app
+  name: custom-single-app
+  annotations:
+    version: v1.0.0
+    description: "Customized version of single-app"
 spec:
   variables:
     - name: message


### PR DESCRIPTION
Readers of the spec have been confused about the `description` and `version` fields.
According to the latest definition, we have annotations for these:
https://github.com/microsoft/hydra-spec/blob/master/3.component_model.md#annotations-format

This PR makes the correction to all the examples.