### PR TITLE
Use generic example in scope

### DIFF
--- a/4.application_scopes.md
+++ b/4.application_scopes.md
@@ -123,7 +123,7 @@ spec:
 ```
 
 ### Health scope
-The health scope aggregates health states for components. Parameters of the health scope can be set to determine the percentage of components that must be unhealthy to consider  the entire scope unhealthy.
+The health scope aggregates health states for components. Parameters of the health scope can be set to determine the percentage of components that must be unhealthy to consider the entire scope unhealthy.
 
 The health scope on its own does not take any action based on health status. It is only a group health aggregator that can be queried and used by other processes and parts of an application, such as:
  - Application upgrade traits can monitor the aggregate health of a health scope and decide when to initiate an automatic rollback.
@@ -145,12 +145,12 @@ spec:
       description: The % of healthy components required to upgrade scope
       type: double
       required: Y
-    - name: LogAnalyticsWorkspaceId
-      description: an Id for a unique environment for Azure Monitor log data
+    - name: logAnalyticsQueryId
+      description: an Id for querying log data from your log system
       type: string
       required: false
-    - name: LogAnalyticsWorkspaceKey
-      description: a key for a unique environment for Azure Monitor log data
+    - name: logAnalyticsQueryKey
+      description: a key for querying log data from your log system
       type: string
       required: false
 ```


### PR DESCRIPTION
It actually took me a moment to dig out what is "Azure Monitor" in order to understand this example accurately :-) 

This raises a thought that we may want to replace it with generic terms?

In this PR I just translated `Azure Monitor` to `your log system`, and removed terms like `WorkspaceId` and `WorkspaceKey`, but feel free to comment if other translations fit more to this case.

Signed-off-by: Harry Zhang <lei.zhang@alibaba-inc.com>