### PR TITLE
rename operational configuration to application configuration

### DIFF
--- a/1.purpose_and_goals.md
+++ b/1.purpose_and_goals.md
@@ -11,7 +11,7 @@ This open specification defines:
 - __Component schematics__, where developers declare the operational characteristics of the code they deliver _in infrastructure neutral terms_.
 - __Application scopes__, a way to group components into loosely coupled applications with common characteristics.
 - __Traits__ for assigning operational features to instances of components.
-- __Operational configuration__, defines a deployment of components, their traits, and application scopes.
+- __Application configuration__, defines a deployment of components, their traits, and application scopes.
 - __Workload types and configurations__, which describe the underlying runtime for a particular workload, as well as exposing per-application configuration.
 
 Additional goals of the specification are to:

--- a/2.overview_and_terminology.md
+++ b/2.overview_and_terminology.md
@@ -26,7 +26,7 @@ The application model defines the following:
  - _Workload types_ identify the different workloads that a component can execute.
  - _Traits_ are overlays that augment a component with additional operations-specific features. Traits represent operator concerns, not developer concerns.
  - _Application scopes_ represent application boundaries by grouping components with common properties or dependencies.
- - An _operational configuration_ describes a set of component instances, their traits, and the application scopes in which they are placed, combined with configuration parameters and metadata.
+ - An _application configuration_ describes a set of component instances, their traits, and the application scopes in which they are placed, combined with configuration parameters and metadata.
 
 Thus, an _application_ is a collection of _components_ with a set of operational traits and scoped together into one or more application boundaries. 
 
@@ -139,15 +139,15 @@ A trait is described as:
 
 - Metadata: Information about the trait
 - Applies-to list: Enumeration of which workload types this trait applies to
-- Parameters: Configuration that may be specified in an operational configuration
+- Parameters: Configuration that may be specified in an application configuration
 
-### Operational Configuration
+### Application Configuration
 
-An operational configuration is a resource that declares how an application (described as an application schematic and component schematics) can be instantiated and configured, including which parameter overrides and add-on traits.
+An application configuration is a resource that declares how an application (described as an application schematic and component schematics) can be instantiated and configured, including which parameter overrides and add-on traits.
 
-An operational configuration has the following parts:
+An application configuration has the following parts:
 
-- Metadata: Information about the application instance
+- Metadata: Information about the installed application configuration
 - Parameter Overrides: Values to supply to named parameters in the application or components
 - Trait configuration: A list of traits to enable, together with parameter overrides for each trait
 - Workload type settings: Overrides to workload type settings

--- a/3.component_model.md
+++ b/3.component_model.md
@@ -2,7 +2,7 @@
 
 This section defines the component model.
 
-Components describe functional units that may be instantiated as part of a larger distributed application. For example, each microservice in an application is described as a component. The description itself is not an instance of that microservice, but a declaration of the operational capabilities of that microservice. [Section 6, Operational Configuration](6.operational_configuration.md) describes how components are grouped together and how instances of those components are then configured.
+Components describe functional units that may be instantiated as part of a larger distributed application. For example, each microservice in an application is described as a component. The description itself is not an instance of that microservice, but a declaration of the operational capabilities of that microservice. [Section 6, Application Configuration](6.application_configuration.md) describes how components are grouped together and how instances of those components are then configured.
 
 ## Component Schematics
 

--- a/4.application_scopes.md
+++ b/4.application_scopes.md
@@ -30,7 +30,7 @@ Core application scope types define grouping constructs for basic runtime behavi
  - Core application scope types MUST all be supported by any implementation of the specification. They may be implemented by any available feature in the platform, but they MUST be implemented according to the specification of each core application scope type.
  - Instances of core *workload* types MUST be deployed into an instance of each core application scope type. 
  - Runtimes MUST provide a default "root" application scope instance for each core application scope type.
- - Runtimes MUST deploy each component instances into default "root" application scope instances when an operational configuration does not otherwise specify an application scope for a component instance.
+ - Runtimes MUST deploy each component instances into default "root" application scope instances when an application configuration does not otherwise specify an application scope for a component instance.
 
  The following core application scope types are defined by this specification:
 
@@ -88,7 +88,7 @@ The parameters that a scope exposes to operators.
 | `default` | type indicated by `type` field | N | | The parameter's default value. |
 
 ## Deployment
-Application scope instances are defined and deployed in an operational configuration. See [Operational Configuration](6.operational_configuration.md) for more information on deploying scopes.
+Application scope instances are defined and deployed in an application configuration. See [Application Configuration](6.application_configuration.md) for more information on deploying scopes.
 
 ## Core scope type definitions
 The following core scope types are available:

--- a/5.traits.md
+++ b/5.traits.md
@@ -1,6 +1,6 @@
 # 5. Traits
 
-A _trait_ is a discretionary runtime overlay that augments a component workload type (`workloadType`) with additional features. It is an opportunity for those in the _application operator_ role to make specific decisions about the configuration of components, but without involving the developer. A trait can be any operational configuration of a distributed application that applies to an individual component, such as traffic routing rules (e.g., load balancing policy, network ingress routing, circuit breaking, rate limiting), auto-scaling policies, upgrade strategies, and more.
+A _trait_ is a discretionary runtime overlay that augments a component workload type (`workloadType`) with additional features. It is an opportunity for those in the _application operator_ role to make specific decisions about the configuration of components, but without involving the developer. A trait can be any configuration of a distributed application that applies to an individual component, such as traffic routing rules (e.g., load balancing policy, network ingress routing, circuit breaking, rate limiting), auto-scaling policies, upgrade strategies, and more.
 
 The _traits system_ is defined in this specification as the way a runtime applies and manages operational behaviors to instances of components through traits.
 
@@ -8,7 +8,7 @@ Runtime implementations of the specification MUST provide the traits system for 
 
 ## Traits system rules and characteristics 
 
-Traits are applied to component instances in the [operational configuration](6.operational_configuration.md). 
+Traits are applied to component instances in the [application configuration](6.application_configuration.md). 
 
 Traits should be applied into the runtime at installation/upgrade time. Traits should not be checked "lazily", but should be checked when the trait-holding components are created.
 
@@ -134,11 +134,11 @@ spec:
 
 #### Usage examples
 
-The following snippet from an operational configuration shows how the manual scaler trait is applied and configured for a component. In this example, it is assumed component `frontend` has a workload type of `core.hydra.io/v1alpha1.Service`.
+The following snippet from an application configuration shows how the manual scaler trait is applied and configured for a component. In this example, it is assumed component `frontend` has a workload type of `core.hydra.io/v1alpha1.Service`.
 
 ```yaml
 apiVersion: core.hydra.io/v1alpha1
-kind: OperationalConfiguration
+kind: ApplicationConfiguration
 metadata:
   name: custom-single-app
   annotations:
@@ -156,9 +156,9 @@ spec:
             replicaCount: 5
 ```
 
-This example illustrates using the manual scaler trait to manually scale a component by specifying the number of replicas the runtime should create. This trait has only one attribute in its properties: `replicaCount`. This takes an integer, and a value is required for this trait to be successfully applied. If, for example, an operational configuration used this trait but did not provide the `replicaCount`, the system would reject the operational configuration.
+This example illustrates using the manual scaler trait to manually scale a component by specifying the number of replicas the runtime should create. This trait has only one attribute in its properties: `replicaCount`. This takes an integer, and a value is required for this trait to be successfully applied. If, for example, an application configuration used this trait but did not provide the `replicaCount`, the system would reject the application configuration.
 
 
 | Previous Part        | Next Part           | 
 | ------------- |-------------|
-| [4. Application Scopes](4.application_scopes.md) | [6. Operational Configuration](6.operational_configuration.md) |
+| [4. Application Scopes](4.application_scopes.md) | [6. Application Configuration](6.application_configuration.md) |

--- a/6.application_configuration.md
+++ b/6.application_configuration.md
@@ -1,10 +1,10 @@
-# 6. Operational Configuration
+# 6. Application Configuration
 
-This section describes how applications are deployed using operational configurations.
+This section describes how applications are deployed using application configurations.
 
 A component schematic can be deployed into any number of runtimes, any number of times. We call each deployment of a component an _instance_. Each time a component is deployed, it must be deployed _with a configuration_. This section of the specification describes configurations.
 
-An _operational configuration_ (sometimes abbreviated to _configuration_) is managed by the _app operator_ role, and provides information specific to the current instance of a component. The following information is considered specific to the runtime instance of a component:
+An _application configuration_ (sometimes abbreviated to _configuration_) is managed by the _app operator_ role, and provides information specific to the current instance of a component. The following information is considered specific to the runtime instance of a component:
 
 - Information about this particular instance, such as:
     - Name
@@ -27,7 +27,7 @@ In 12 factor applications, a release is defined as a [build plus a set of config
 
 For components, release is defined thus:
 
-> A release is a named instantiation of a component package, together with its operational configuration
+> A release is a named instantiation of a component package, together with its application configuration
 
 The following are characteristics of a release:
 
@@ -43,13 +43,13 @@ For these reasons, the following conditions trigger a new release:
 - A rollback event (where the release version number is changed) even if the configuration and component package are the same
 - A change in the release name. In this case, the versioning should also be reset to its starting value, and this should be treated as a new component instance
 
-## Runtime and Operational Configuration
+## Runtime and Application Configuration
 
 The [Component Model](3.component_model.md) chapter of the specification defines how schematics are constructed. The resulting schematics may then be used to instantiate a component on a Hydra-compliant runtime.
 
-Component schematics can be deployed into numerous different runtimes. But at runtime, there is a one-to-one correspondence between an _instance of an configuration_ and an _operational configuration_.
+Component schematics can be deployed into numerous different runtimes. But at runtime, there is a one-to-one correspondence between an _instance of an configuration_ and an _application configuration_.
 
-Conceptually speaking, an operational configuration is managed as part of the _application operator_ role. It has three main sections:
+Conceptually speaking, an application configuration is managed as part of the _application operator_ role. It has three main sections:
 
 - Parameters that can be supplied by an application operator at deployment time.
 - A list of application scopes, each of which has overrides for that scope's parameters.
@@ -58,17 +58,17 @@ Conceptually speaking, an operational configuration is managed as part of the _a
   - A list of traits, each of which has overrides for that trait's parameters.
   - A list of application scopes that the component should be deployed into.
 
-## Defining an operational configuration
+## Defining an application configuration
 
 ### Top-Level Attributes
-The top-level attributes of a operational configuration define its metadata, version, kind, and spec.
+The top-level attributes of a application configuration define its metadata, version, kind, and spec.
 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
 | `apiVersion` | `string` | Y || The specific version of the specification in use. At present only `core.hydra.io/v1alpha1` is defined. |
-| `kind` | `string` | Y || The string `OperationalConfiguration` |
-| `metadata` | [`Metadata`](#metadata) | Y | | Operational configuration metadata. |
-| `spec`| [`Spec`](#spec) | Y || A container for exposing operational configuration attributes. |
+| `kind` | `string` | Y || The string `ApplicationConfiguration` |
+| `metadata` | [`Metadata`](#metadata) | Y | | Application configuration metadata. |
+| `spec`| [`Spec`](#spec) | Y || A container for exposing application configuration attributes. |
 
 ### Metadata
 Metadata describes this trait. The metadata section is defined in [Section 3](3.component_model.md#metadata).
@@ -85,7 +85,7 @@ The specification defines three major things: Parameters that can be overridden 
 
 
 ### Variable
-The Variables section defines variables that may be used elsewhere in the operational configuration. The `variable` section provides a way for an application operator to specify common values that can be substituted into multiple other locations in this configuration (using the `[fromVariable(VARNAME)]` syntax).
+The Variables section defines variables that may be used elsewhere in the application configuration. The `variable` section provides a way for an application operator to specify common values that can be substituted into multiple other locations in this configuration (using the `[fromVariable(VARNAME)]` syntax).
 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
@@ -95,7 +95,7 @@ The Variables section defines variables that may be used elsewhere in the operat
 The function `[fromVariable(VARNAME)]` (where `VARNAME` corresponds to the `name` field in a variable definition) may be used in predefined locations (parameter values and properties objects) to access the `value` of a parameter.
 
 ### Scope
-The scope section defines application scopes that will be created with this operational configuration.
+The scope section defines application scopes that will be created with this application configuration.
 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
@@ -104,7 +104,7 @@ The scope section defines application scopes that will be created with this oper
 | `properties` | [`Properties`](#properties) | N | | The properties attached to this scope. |
 
 ### Component
-This section defines the instances of components to create with this operational configuration.
+This section defines the instances of components to create with this application configuration.
 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
@@ -153,7 +153,7 @@ The following is an example of a complete YAML file that expresses configuration
 
 ```yaml
 apiVersion: core.hydra.io/v1alpha1
-kind: OperationalConfiguration
+kind: ApplicationConfiguration
 metadata:
   name: my-app-deployment
   annotations:
@@ -185,7 +185,7 @@ spec:
               
 ```
 
-The example above illustrates a complete operational configuration scopes, component instances, their traits, and parameter overrides that allow users to specify values at deployment time from the command line.
+The example above illustrates a complete application configuration scopes, component instances, their traits, and parameter overrides that allow users to specify values at deployment time from the command line.
 
 ## An Example Workflow
 This section is non-normative. Hydra compliant tooling need not implement this section.
@@ -250,11 +250,11 @@ Note that each component allows certain parameters to be overridden. For example
 
 Components can be designed for reuse by expose such parameters, as these parameters can be tweaked for different deployment scenarios.
 
-An operational configuration combines any number of components and sets operational characteristics and configuration for a deployed _instance_ of each component. 
+An application configuration combines any number of components and sets operational characteristics and configuration for a deployed _instance_ of each component. 
 
 ```yaml
 apiVersion: core.hydra.io/v1alpha1
-kind: OperationalConfiguration
+kind: ApplicationConfiguration
 metadata:
   name: custom-single-app
   annotations:
@@ -296,11 +296,11 @@ $ hyctl trait-list
 ╚════════════╧═════════╧═════════════════════════════════════════════╝
 ```
 
-Here is how the previous operational configuration looks with an `ingress` trait attached to the front-end component:
+Here is how the previous application configuration looks with an `ingress` trait attached to the front-end component:
 
 ```yaml
 apiVersion: core.hydra.io/v1alpha1
-kind: OperationalConfiguration
+kind: ApplicationConfiguration
 metadata:
   name: custom-single-app
   annotations:
@@ -328,7 +328,7 @@ spec:
               value: "/"
 ```
 
-This example attaches an `ingress` to route traffic from another network (public, perhaps) to the internal service. This configuration shows how the trait is both attached and configured. In this example, a new parameter named `domainName` is added to the operational configuration, allowing a user to override the `host` parameter of the `ingress` trait.
+This example attaches an `ingress` to route traffic from another network (public, perhaps) to the internal service. This configuration shows how the trait is both attached and configured. In this example, a new parameter named `domainName` is added to the application configuration, allowing a user to override the `host` parameter of the `ingress` trait.
 
 An implementation of this would then direct inbound traffic bound for `www.example.com` to the `front-end` component.
 
@@ -338,11 +338,11 @@ Up to this point, the frontend component is deployed into the default "root" net
 
 The backend component is an extended workload type and is therefore not automatically deployed into the default "root' application scopes.
 
-In this example, a network scope is defined and attached to an SDN. Both components are then added to the same network scope for direct network connectivity and a shared set of network policies that can be defined by the infrastructure operator on the SDN itself. The SDN name is parameterized in the operational configuration to allow an application operator to deploy this configuration into any SDN.
+In this example, a network scope is defined and attached to an SDN. Both components are then added to the same network scope for direct network connectivity and a shared set of network policies that can be defined by the infrastructure operator on the SDN itself. The SDN name is parameterized in the application configuration to allow an application operator to deploy this configuration into any SDN.
 
 ```yaml
 apiVersion: core.hydra.io/v1alpha1
-kind: OperationalConfiguration
+kind: ApplicationConfiguration
 metadata:
   name: custom-single-app
   annotations:
@@ -385,7 +385,7 @@ spec:
         - myNetworkScope
 ```
 
-This example now shows a complete application instance composed of two components, an ingress trait, and a network scope with parameters exposed to an application operator to customize the application's domain name, the network to deploy it to, and a custom message for the application to display.
+This example now shows a complete installation of the application configuration composed of two components, an ingress trait, and a network scope with parameters exposed to an application operator to customize the domain name, the network to deploy it to, and a custom message for the web front end to display.
 
 | Tables        | Next           | 
 | ------------- |-------------| 

--- a/7.workload_types.md
+++ b/7.workload_types.md
@@ -53,4 +53,4 @@ Settings describe which pieces of a workload type are configurable.
 
 | Previous        | Next           | 
 | ------------- |-------------|
-| [6. Operational Configuration](6.operational_configuration.md) | [8. Practical Considerations](8.practical_considerations.md) |
+| [6. Application Configuration](6.application_configuration.md) | [8. Practical Considerations](8.practical_considerations.md) |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ open specifications.
   3. [The Component Model](3.component_model.md)
   4. [Application Scopes](4.application_scopes.md)
   5. [Traits](5.traits.md)
-  6. [Operational Configuration](6.operational_configuration.md)
+  6. [Application Configuration](6.application_configuration.md)
   7. [Workload Types](7.workload_types.md)
   8. [Practical Considerations](8.practical_considerations.md)
   9. [Design Principles](9.design_principles.md)

--- a/schema/application_configuration.schema.json
+++ b/schema/application_configuration.schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "http://microsoft.com/v1/hydra.operational_configuration.schema.json",
-    "title": "Hydra Operational Configuration JSON Schema",
+    "$id": "http://microsoft.com/v1/hydra.application_configuration.schema.json",
+    "title": "Hydra Application Configuration JSON Schema",
     "type": "object",
     "properties": {
         "apiVersion": {
@@ -10,55 +10,66 @@
         },
         "kind": {
             "type": "string",
-            "description": "For an operational configuration schematic, must be OperationalConfiguration.",
-            "enum": ["OperationalConfiguration"]
+            "description": "For an application configuration schematic, must be ApplicationConfiguration.",
+            "enum": [
+                "ApplicationConfiguration"
+            ]
         },
         "metadata": {
             "type": "object",
-            "description": "Operational configuration metadata.",
+            "description": "Application configuration metadata.",
             "properties": {
                 "name": {
-                    "type":"string"
+                    "type": "string"
                 },
                 "labels": {
-                    "type":"object",
+                    "type": "object",
                     "description": "A set of string key/value pairs used as arbitrary labels on this operational configuration.",
-                    "additionalProperties": { "type": "string" }
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "annotations": {
-                    "type":"object",
+                    "type": "object",
                     "description": "A set of string key/value pairs used as arbitrary annotations on this operational configuration.",
-                    "additionalProperties": { "type": "string" }
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 }
             }
         },
         "spec": {
             "type": "object",
-            "description": "A container for exposing operational configuration attributes.",
+            "description": "A container for exposing application configuration attributes.",
             "additionalProperties": {
                 "$ref": "#/definitions/operationalConfigurationSpec"
             }
         }
     },
-    "required": ["apiVersion", "kind", "metadata", "spec"],
+    "required": [
+        "apiVersion",
+        "kind",
+        "metadata",
+        "spec"
+    ],
     "additionalProperties": false,
     "definitions": {
         "operationalConfigurationSpec": {
-            "variables":{
+            "variables": {
                 "type": "array",
                 "description": "Variables that can be referenced in parameter values and properties.",
                 "items": {
                     "$ref": "#/definitions/opconfigVariable"
                 }
             },
-            "scopes":{
+            "scopes": {
                 "type": "array",
                 "description": "Application scope definitions.",
                 "items": {
                     "$ref": "#/definitions/applicationScope"
                 }
             },
-            "components":{
+            "components": {
                 "type": "array",
                 "description": "Component instance definitions.",
                 "items": {
@@ -70,7 +81,7 @@
         },
         "opconfigVariable": {
             "type": "object",
-            "description": "The Variables section defines variables that may be used elsewhere in the operational configuration. The variable section provides a way for an application operator to specify common values that can be substituted into multiple other locations in this configuration (using the [fromVariable(VARNAME)] syntax).",
+            "description": "The Variables section defines variables that may be used elsewhere in the application configuration. The variable section provides a way for an application operator to specify common values that can be substituted into multiple other locations in this configuration (using the [fromVariable(VARNAME)] syntax).",
             "properties": {
                 "name": {
                     "type": "string",
@@ -83,12 +94,15 @@
                     "description": "The scalar value."
                 }
             },
-            "required": ["name", "value"],
+            "required": [
+                "name",
+                "value"
+            ],
             "additionalProperties": false
         },
         "applicationScope": {
             "type": "object",
-            "description": "The scope section defines application scopes that will be created with this operational configuration.",
+            "description": "The scope section defines application scopes that will be created with this application configuration.",
             "properties": {
                 "name": {
                     "type": "string",
@@ -106,12 +120,15 @@
                     }
                 }
             },
-            "required": ["name", "type"],
+            "required": [
+                "name",
+                "type"
+            ],
             "additionalProperties": false
         },
         "componentInstance": {
             "type": "object",
-            "description": "This section defines the instances of components to create with this operational configuration.",
+            "description": "This section defines the instances of components to create with this application configuration.",
             "properties": {
                 "componentName": {
                     "type": "string",
@@ -121,14 +138,14 @@
                     "type": "string",
                     "description": "The name of the instance of this component."
                 },
-                "parameterValues":{
+                "parameterValues": {
                     "type": "array",
                     "description": "Overrides of parameters that are exposed by the application scope type defined in 'type'.",
                     "items": {
                         "$ref": "#/definitions/parameterValue"
                     }
                 },
-                "traits":{
+                "traits": {
                     "type": "array",
                     "description": "Specifies the traits to attach to this component instance.",
                     "items": {
@@ -136,7 +153,10 @@
                     }
                 }
             },
-            "required": ["componentName", "instanceName"],
+            "required": [
+                "componentName",
+                "instanceName"
+            ],
             "additionalProperties": false
         },
         "parameterValue": {
@@ -154,7 +174,9 @@
                     "description": "The value of this parameter."
                 }
             },
-            "required": ["name"],
+            "required": [
+                "name"
+            ],
             "additionalProperties": false
         },
         "trait": {
@@ -177,7 +199,10 @@
                     }
                 }
             },
-            "required": ["name", "type"],
+            "required": [
+                "name",
+                "type"
+            ],
             "additionalProperties": false
         },
         "propertiesObject": {


### PR DESCRIPTION
Per #95, this renames OperationalConfiguration (and all related terminology) to ApplicationConfiguration (with related terminology).

BREAKING CHANGE.

Closes #95