### PR TITLE
Prepend 'replicable' to all replicable workload types

### DIFF
--- a/3.component_model.md
+++ b/3.component_model.md
@@ -133,7 +133,7 @@ Workloads are named using a simple convention: `GROUP/VERSION.KIND`, where `GROU
 
 Examples:
 
-- `core.hydra.io/v1alpha1.Singleton`: The group is `core.hydra`, meaning it is built-in. The version indicates that this is still an alpha version (`v1alpha1`). The kind is `Singleton`. This means the core singleton runtime must be used for this component.
+- `core.hydra.io/v1alpha1.SingletonService`: The group is `core.hydra`, meaning it is built-in. The version indicates that this is still an alpha version (`v1alpha1`). The kind is `Singleton`. This means the core singleton runtime must be used for this component.
 - `azure.com/v1.Function`: The group is `azure.com` (which is a vendor-specific implementation, and may not be present on all runtimes). The version is `v1`, which marks this as stable. The kind is `Function`, whose runtime implementation is the Azure Functions offering.
 - `streams.hydra.io/v1beta2.Kafka`: The group is `streams.hydra.io`, a hypothetical location where certain vendor-neutral extensions may exist. Version is `v1beta2`, indicating that it is moving toward stability. And the kind is `Kafka`.
 - `caching.hydra.io/v2.Redis`: The group is `caching.hydra.io`, version is `v2`, and the kind is `Redis`. This describes an implementation of a Redis cache.
@@ -163,21 +163,21 @@ The following core workload types are defined by this specification:
 
 |Name|Type|Service endpoint|Replicable|Daemonized|
 |-|-|-|-|-|
-|Service|core.hydra.io/v1alpha1.Service|Yes|Yes|Yes
+|Service|core.hydra.io/v1alpha1.ReplicableService|Yes|Yes|Yes
 |Singleton Service|core.hydra.io/v1alpha1.SingletonService|Yes|No|Yes
-|Worker|core.hydra.io/v1alpha1.Worker|No|Yes|Yes
+|Worker|core.hydra.io/v1alpha1.ReplicableWorker|No|Yes|Yes
 |Singleton Worker|core.hydra.io/v1alpha1.SingletonWorker|No|No|Yes
-|Task|core.hydra.io/v1alpha1.Task|No|Yes|No
+|Task|core.hydra.io/v1alpha1.ReplicableTask|No|Yes|No
 |Singleton Task|core.hydra.io/v1alpha1.SingletonTask|No|No|No
 
-##### Service 
-Workload type name: `core.hydra.io/v1alpha1.Service`
+##### Replicable Service 
+Workload type name: `core.hydra.io/v1alpha1.ReplicableService`
 
-A service is used for long-running, scalable workloads that have a network endpoint with a stable name to receive network traffic for the component as a whole. Common use cases include web applications and services that expose APIs. The Service workload type has the following characteristics:
+A replicable service is used for long-running, scalable workloads that have a network endpoint with a stable name to receive network traffic for the component as a whole. Common use cases include web applications and services that expose APIs. The Service workload type has the following characteristics:
  - Defines a container runtime where zero or more replicas of the same container may be run simultaneously. 
  - An application operator can increase or decrease the number of service replicas by applying and configuring traits when available. 
- - A service is daemonized. A runtime MUST attempt to restart replicas that exit regardless of error code.
- - A service has a network endpoint with an automatically assigned virtual IP address (VIP) and DNS name addressable within the network scope to which the component belongs.
+ - A replicable service is daemonized. A runtime MUST attempt to restart replicas that exit regardless of error code.
+ - A replicable service has a network endpoint with an automatically assigned virtual IP address (VIP) and DNS name addressable within the network scope to which the component belongs.
 
 ##### Singleton Service
 Workload type name: `core.hydra.io/v1alpha1.SingletonService`
@@ -187,13 +187,13 @@ A singleton service is a special case of the Service workload type that is limit
  - A singleton service is daemonized. A runtime MUST attempt to restart the singleton replica if it exits regardless of error code.
  - A singleton service has a network endpoint with an automatically assigned virtual IP address (VIP) and DNS name addressable within the network scope to which the component belongs.
 
-##### Worker
-Workload type name: `core.hydra.io/v1alpha1.Worker`
+##### Replicable Worker
+Workload type name: `core.hydra.io/v1alpha1.ReplicableWorker`
 
-A worker is used for long-running, scalable workloads that do not have a service endpoint for network requests, aside from optional liveliness and readiness probe endpoints on individual replicas. Workers are typically used to pull from queues or provide other offline processing. The worker workload type has the following characteristics:
+A replicable worker is used for long-running, scalable workloads that do not have a service endpoint for network requests, aside from optional liveliness and readiness probe endpoints on individual replicas. Workers are typically used to pull from queues or provide other offline processing. The worker workload type has the following characteristics:
  - Defines a container runtime where zero or more replicas of the same container may be run simultaneously. 
  - An application operator can increase or decrease the number of worker replicas by applying and configuring traits when available.
- - A worker is daemonized. A runtime MUST attempt to restart replicas that exit regardless of error code.
+ - A replicable worker is daemonized. A runtime MUST attempt to restart replicas that exit regardless of error code.
 
 ##### Singleton Worker
 Workload type name: `core.hydra.io/v1alpha1.SingletonWorker`
@@ -203,13 +203,13 @@ A singleton worker is a special case of the worker workload type that is limited
  - A singleton worker is daemonized. A runtime MUST attempt to restart the singleton replica if it exits regardless of error code.
 
 
-##### Task
-Workload type name: `core.hydra.io/v1alpha1.Task`
+##### Replicable Task
+Workload type name: `core.hydra.io/v1alpha1.ReplicableTask`
 
-A task is used to run code or a script to completion. Commonly used to run cron jobs or one-time highly parallelizable tasks that exit and free up resources upon completion. The task workload type has the following characteristics:
+A replicable task is used to run code or a script to completion. Commonly used to run cron jobs or one-time highly parallelizable tasks that exit and free up resources upon completion. The task workload type has the following characteristics:
  - Defines a container runtime where zero or more replicas of the same container may be run simultaneously.
  - An application operator can increase or decrease the number of worker replicas by applying and configuring traits when available
-  - A task is non-daemonized. A runtime MUST NOT attempt to restart replicas that exit without an error code.
+  - A replicable task is non-daemonized. A runtime MUST NOT attempt to restart replicas that exit without an error code.
 
 ##### Singleton Task
 Workload type name: `core.hydra.io/v1alpha1.SingletonTask`
@@ -515,7 +515,7 @@ configuration to disk as a JSON file.
 
 This component's design prevents it from scaling horizontally, so we should only
 have at most _one_ instance of it running. As such, this component is described
-as a `Singleton`. Connection details for the Twitter API are
+as a `SingletonService`. Connection details for the Twitter API are
 configurable. The component schematic also describes the file system location
 where the component persists end-user-defined configuration.
 

--- a/6.operational_configuration.md
+++ b/6.operational_configuration.md
@@ -207,7 +207,7 @@ metadata:
     version: v1.0.0
     description: "A simple webserver"
 spec:
-  workloadType: core.hydra.io/v1.Replicated
+  workloadType: core.hydra.io/v1.ReplicableService
   parameters:
     - name: message
       description: The message to display in the web app.
@@ -291,9 +291,9 @@ $ hyctl trait-list
 ╔════════════╤═════════╤═════════════════════════════════════════════╗
 ║ NAME       │ VERSION │ PRIMITIVES                                  ║
 ╟────────────┼─────────┼─────────────────────────────────────────────╢
-║ autoscaler │ 0.1.0   │ replicatedService, quorumService            ║
+║ autoscaler │ 0.1.0   │ ReplicableService, ReplicableTask           ║
 ╟────────────┼─────────┼─────────────────────────────────────────────╢
-║ ingress    │ 0.1.0   │ singleton, replicatedService, quorumService ║
+║ ingress    │ 0.1.0   │ SingletonService, ReplicableService         ║
 ╚════════════╧═════════╧═════════════════════════════════════════════╝
 ```
 
@@ -337,7 +337,7 @@ An implementation of this would then direct inbound traffic bound for `www.examp
 
 Up to this point, the frontend component is deployed into the default "root" network and health scopes, as all core workload types are required to be in all core application scope types.
 
-The backend component is an extended workload type and is therefore not automatically deployed into the default "root' application scopes.
+The backend component is an extended workload type and is therefore not automatically deployed into the default "root" application scopes.
 
 In this example, a network scope is defined and attached to an SDN. Both components are then added to the same network scope for direct network connectivity and a shared set of network policies that can be defined by the infrastructure operator on the SDN itself. The SDN name is parameterized in the operational configuration to allow an application operator to deploy this configuration into any SDN.
 

--- a/7.workload_types.md
+++ b/7.workload_types.md
@@ -35,9 +35,9 @@ This section describes the different naming references for this kind.
 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
-| `kind` | `string` | Y | | The proper reference name of the workload type (`Singleton`) |
-| `singular` | `string` | N | | The singular human-readable name of this type (`singleton`) |
-| `plural` | `string` | N | | The plural human-readable name of this type (`singletons`) |
+| `kind` | `string` | Y | | The proper reference name of the workload type (`SingletonService`) |
+| `singular` | `string` | N | | The singular human-readable name of this type (`singletonservice`) |
+| `plural` | `string` | N | | The plural human-readable name of this type (`singletonservices`) |
 
 #### Setting
 

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -59,7 +59,7 @@
             "workloadType":{
                 "type": "string",
                 "description": "A succinct, semantically meaningful descriptor of the component's runtime profile.",
-                "enum": ["Service", "SingletonService", "Worker", "Singleton Worker", "Task", "Singleton Task"]
+                "enum": ["ReplicableService", "SingletonService", "ReplicableWorker", "SingletonWorker", "ReplicableTask", "SingletonTask"]
             },
             "osType":{
                 "type": "string",


### PR DESCRIPTION
This walks back an earlier change that removed 'replicable' from workload type names.

Because changing 'ReplicableService' to 'Service' causes user-facing ambiguity and confusion, this PR reverts that change.

Closes #86