### PR TITLE
Clarify wording on application scope types

### DIFF
--- a/4.application_scopes.md
+++ b/4.application_scopes.md
@@ -69,9 +69,11 @@ The spec defines the constituent parts of a scope.
 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
-| `type` | `string` | Y | | Determines type of the application scope. |
+| `type` | `string` | Y | | Determines type of the application scope. The core types are defined [above](#core-application-scope-types) |
 | `allowComponentOverlap` | `bool` | Y | | Determines whether a component is allowed to be in multiple instances of this scope type simultaneously. When false, the runtime implementation MUST produce an error and stop deployment if an attempt is made to place a component into more than one instance of this scope type simultaneously. |
 | `parameters` | [`[]Parameter`](#parameter) | N | | The scope's configuration options. |
+
+The `type` field defines the type name for this type. Examples may be found in the [Core Application Scope Types](#core-application-scope-types) above. Extended scope types MUST NOT be in the `core.hydra.io` namespace.  However, they must follow the [group, version, kind notation](2.overview_and_terminology.md). For example: `scopes.example.com/v1.ExtendedNetworkScope`
 
 #### Parameter
 


### PR DESCRIPTION
This clarifies the wording around how scopes are defined, and how type is specified.

Closes #63