### PR TITLE
Clarify default if network scopes are not attached

### DIFF
--- a/4.application_scopes.md
+++ b/4.application_scopes.md
@@ -98,6 +98,8 @@ The network scope groups components together and links them to a network or SDN.
 
 The network scope may also be queried by traffic management traits to determine discoverability boundaries for a service mesh or API boundaries for API gateways.
 
+If no network scope is assigned, the platform MUST join the application to a default network. Within that default network, all components in the application configuration MUST be able to communicate to each other, and health probes MUST be able to contact any components who define health checking rules. The network joined, however, is platform-dependent. For example, cluster-based environments (such as Kubernetes) declare cluster-wide networks. Conversely, a truly serverless implementation may join the components to a network that only includes the components and the health checking probes.
+
 #### Example
 This is an example of a network scope definition. 
 ```yaml


### PR DESCRIPTION
This declares what happens when no network scope is attached.

Closes #67