### PR TITLE
Specify naming rules

### DIFF
--- a/3.component_model.md
+++ b/3.component_model.md
@@ -79,6 +79,8 @@ The Parameters section defines all of the configurable parameters for this compo
 | `required` | `boolean` | N |`false` | Whether a value _must_ be provided for the parameter. |
 | `default` | type indicated by `type` field | N | | The parameter's default value. |
 
+Parameter `name` fields must be Unicode letter and number characters.
+
 ### Workload Types
 
 A _workload type_ is an indicator to the runtime as to how it should execute the given workload. In other words, it provides a single field by which the developer can indicate to the runtime how the developer intends for this component to be executed.
@@ -206,6 +208,8 @@ This section describes the runtime configuration necessary to run a containerize
 The details of the way that a runtime takes `imagePullSecret` and loads credentials is left to the Hydra runtime implementation. For example, a Kubernetes implementation may treat this as a key that can be [loaded from a secret](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
 While it is not required, it is RECOMMENDED that `image` names be suffixed with a digest in [OCI format](https://github.com/opencontainers/image-spec/blob/master/descriptor.md#digests). The digest may be used to compute the integrity of the image. `example/foobar@sha256:72e996751fe42b2a0c1e6355730dc2751ccda50564fec929f76804a6365ef5ef`.
 
+> The name field is required and must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.
+
 ### WorkloadSetting
 
 This section describes additional configuration for a workload (settings that are not about a container runtime).
@@ -218,6 +222,10 @@ This section describes additional configuration for a workload (settings that ar
 | `fromParam` | string | N || The name of the parameter from whence to fetch the setting value. Overrides `value` |
 
 The `workloadSettings` section of a component schematic is an extensible location for specifying workload-specific configuration. The core workload types do not use this section, as it is reserved for extended workloads. Its primary purpose is to hold definitions for _non-containerized extended workload types_, though it may be used for containerized extended workload types where applicable.
+
+> The name field is required and must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.
+
+The `workloadSettings` section of a component schematic is an extensible location for specifying workload-specific configuration. Its primary purpose is to hold definitions for _non-containerized extended workload types_, though it may be used for containerized workload types where applicable.
 
 > The available settings are listed on the workload type object. See [section 7](7.workload_types.md) for details.
 
@@ -333,6 +341,8 @@ Env describes an environment variable as a name/value pair of strings.
 | `value` | `string` | N || The environment variable value. If this is not supplied, `fromParam` must be supplied |
 | `fromParam` | `string` | N || The parameter whose value should be substituted into this variable as a value |
 
+The `name` field must be composed of valid Unicode letter and number characters, as well as `_` and `-`.
+
 Example:
 
 ```yaml
@@ -377,6 +387,8 @@ If both `fromParam` and `value` are specified, `fromParam` MUST take precedence,
 | `containerPort` | `integer` | Y || The port number. Must be unique per container. |
 | `protocol` | `string` | N | `TCP` | Indicates the transport layer protocol used by the server listening on the port. Valid values are `TCP` and `UDP`. |
 
+The `name` field must be lowercase alphabetical characters as present in the ASCII character set (0061-007A).
+
 ### HealthProbe
 
 Health Probe describes how a probing operation is to be executed as a way of determining the health of a component.
@@ -415,11 +427,15 @@ See the Units section above for valid time values.
 | `name` | `string` | Y || An HTTP header name. This must be unique per HTTP GET-based probe. |
 | `value` | `string` | Y || An HTTP header value. |
 
+Both `name` and `value` must abide by the HTTP/1.1 specification for valid [header values](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2)
+
 ### TCPSocket
 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
 | `port` | `integer` | Y || The TCP socket within the container that should be probed to assess container health. |
+
+Port must be an integer value greater than `0`.
 
 ### Examples
 

--- a/4.application_scopes.md
+++ b/4.application_scopes.md
@@ -83,6 +83,8 @@ The parameters that a scope exposes to operators.
 | `required` | `boolean` | N |`false` | Whether a value _must_ be provided for the parameter. |
 | `default` | type indicated by `type` field | N | | The parameter's default value. |
 
+The `name` field allows Unicode letters, numbers and `_` and `-`. The `description` field allows those characters plus whitespace and punctuation characters.
+
 ## Deployment
 Application scope instances are defined and deployed in an application configuration. See [Application Configuration](6.application_configuration.md) for more information on deploying scopes.
 

--- a/6.application_configuration.md
+++ b/6.application_configuration.md
@@ -88,6 +88,8 @@ The Variables section defines variables that may be used elsewhere in the applic
 | `name` | `string` | Y | | The parameter's name. Must be unique per configuration. |
 | `value` | `string` | Y | | The scalar value. |
 
+A `name` is any Unicode letter or numeric character, `_`, `-`, and `.`. A `value` is any sequence of printable Unicode characters.
+
 The function `[fromVariable(VARNAME)]` (where `VARNAME` corresponds to the `name` field in a variable definition) may be used in predefined locations (parameter values and properties objects) to access the `value` of a parameter.
 
 ### Scope
@@ -98,6 +100,8 @@ The scope section defines application scopes that will be created with this appl
 | `name` | `string` | Y | | The name of the application scope. Must be unique to the deployment environment. |
 | `type` | `string` | Y | | The fully-qualified GROUP/VERSION.KIND name of the application scope. |
 | `properties` | [`Properties`](#properties) | N | | The properties attached to this scope. |
+
+> The name field must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.
 
 ### Component
 This section defines the instances of components to create with this application configuration.
@@ -111,6 +115,8 @@ This section defines the instances of components to create with this application
 
 In addition to being unique, the `instanceName` must follow these naming rules:
 
+> The componentName field is required and must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.
+
 > The instanceName segment is required and must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.
 
 ### Trait
@@ -121,6 +127,8 @@ The trait section defines an instance of a trait and its properties (parameter o
 | `name` | `string` | Y | | The name of the trait instance. Must be unique to the deployment environment. |
 | `type` | `string` | Y | | The fully-qualified GROUP/VERSION.KIND name of the trait. |
 | `properties` | [`Properties`](#properties) | N | | Overrides of parameters that are exposed by the trait type defined in `type`. |
+
+> The name field is required and must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.
 
 ### Properties
 
@@ -141,6 +149,8 @@ Values supplied to parameters that are used to override the parameters exposed b
 |-----------|------|----------|---------------|-------------|
 | `name` | `string` | Y | | The name of the component parameter to provide a value for. |
 | `value` | `string` | N || The value of this parameter. |
+
+A `name` is any Unicode letter or numeric character, `_`, `-`, and `.`. A `value` is any sequence of printable Unicode characters.
 
 The `value` field _allows_ use of the `[fromVariable(VARNAME)]` function.
 

--- a/7.workload_types.md
+++ b/7.workload_types.md
@@ -29,6 +29,8 @@ The specification describes how to declare that a component is bound to a worklo
 | `names` | `Names` | Y | | Information about the names associated with this workload type |
 | `settings` | [`[]Setting`](#setting) | N | | The workload type's settings options. |
 
+The format of `group` is described in [the Group, Version, Kind section of part 2](2.overview_and_terminology.md)
+
 #### Names
 
 This section describes the different naming references for this kind.
@@ -38,6 +40,10 @@ This section describes the different naming references for this kind.
 | `kind` | `string` | Y | | The proper reference name of the workload type (`Singleton`) |
 | `singular` | `string` | N | | The singular human-readable name of this type (`singleton`) |
 | `plural` | `string` | N | | The plural human-readable name of this type (`singletons`) |
+
+`kind` must begin with a capital letter, and contain only characters 0030-0039, 0041-005a, and 0061-007a from the Unicode basic Latin characters.
+
+`singular` and `plural` can only contain characters from Unicode basic Latin 0030-0039 and 0061-007a.
 
 #### Setting
 
@@ -50,6 +56,9 @@ Settings describe which pieces of a workload type are configurable.
 | `type` | `string` | Y | | The setting's type (One of `string`, `boolean`, `number`). |
 | `required` | `boolean` | N |`false` | Whether a value _must_ be provided for the setting. |
 | `default` | type indicated by `type` field | N | | The setting's default value. |
+
+The `name` field allows Unicode letters, numbers and `_` and `-`. The `description` field allows those characters plus whitespace and punctuation characters.
+
 
 | Previous        | Next           | 
 | ------------- |-------------|


### PR DESCRIPTION
The naming rules here are mostly derived from Kubernetes' own naming rules, but with some clarifications from the HTTP spec.

Closes #78