### PR TITLE
Add annotations section to JSON Schema

### DIFF
--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -20,17 +20,16 @@
                 "name": {
                     "type":"string"
                 },
-                "description": {
-                    "type":"string",
-                    "description": "A short description of the component."
-                },
-                "version": {
-                    "type":"string",
-                    "description": "A string defining the semantic version of the component."
-                },
                 "labels": {
                     "type":"array",
                     "description": "A set of string key/value pairs used as arbitrary labels on this component.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "annotations": {
+                    "type": "array",
+                    "description": "A set of string key/value pairs used as arbitrary annotations on this component.",
                     "items": {
                         "type": "string"
                     }

--- a/schema/operational_configuration.schema.json
+++ b/schema/operational_configuration.schema.json
@@ -20,17 +20,16 @@
                 "name": {
                     "type":"string"
                 },
-                "description": {
-                    "type":"string",
-                    "description": "A short description of the operational configuration."
-                },
-                "version": {
-                    "type":"string",
-                    "description": "A string defining the semantic version of the operational configuration."
-                },
                 "labels": {
                     "type":"array",
                     "description": "A set of string key/value pairs used as arbitrary labels on this operational configuration.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "annotations": {
+                    "type": "array",
+                    "description": "A set of string key/value pairs used as arbitrary annotations on this operational configuration.",
                     "items": {
                         "type": "string"
                     }


### PR DESCRIPTION
Remove version and description, both of which were relegated to optional fields on the free-form annotations object.

Closes #99