### PR TITLE
Add Mikkel back to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Final Approvers:
-*   @technosophos @vturecek
+*   @technosophos @vturecek @MikkelHegn


### PR DESCRIPTION
This re-adds Mikkel as a final approver. This will remain in effect at least through Vas' absence.

Closes #116