### PR TITLE
Add extended requirements section to Component containers

### DIFF
--- a/3.component_model.md
+++ b/3.component_model.md
@@ -301,7 +301,7 @@ Resources describe compute resources attached to a runtime.
 
 For any resource that cannot be satisfied by the underlying platform, the platform MUST return an error and cease deployment. A resource is considered a requirement, and failure to meet that requirement means the runtime MUST NOT deploy the application. For example, if an application requests `1P` of memory, and that amount of memory is not available, the application deployment must fail. Likewise, if an application requires `1` gpu, and the runtime does not provide gpus, the application deployment MUST fail.
 
-### CPU
+#### CPU
 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
@@ -365,9 +365,9 @@ The disk specifies the attributes of the disk used by the volume. It describes i
 
 See the Units section above for valid values.
 
-### ExtendedResource
+#### ExtendedResource
 
-An extended resource is a declaration of a resource requirement for an implementation-specific resource. For example, Hydra-compliant platforms may expose special hardware. This field allows components to indicate that such special offerings are required in order for the containers to operate.
+An extended resource is a declaration of a resource requirement for an implementation-specific resource. For example, Hydra-compliant platforms may expose special hardware. This field allows containers to indicate that such special offerings are required in order for the containers to operate.
 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|


### PR DESCRIPTION
This allows a way for component authors to declare dependence on extended (possibly platform specific) resources.

Closes #79