### PR TITLE
add expose port in container prot

### DIFF
--- a/3.component_model.md
+++ b/3.component_model.md
@@ -437,7 +437,8 @@ If both `fromParam` and `value` are specified, `fromParam` MUST take precedence,
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
 | `name` | `string` | Y || A descriptive name for the port. Must be unique per container. |
-| `containerPort` | `integer` | Y || The port number. Must be unique per container. |
+| `containerPort` | `integer` | Y || The port number which the container will listen on. Must be unique per container. |
+| `servicePort` | `integer` | Y || The port number to expose for service. Must be unique per container. |
 | `protocol` | `string` | N | `TCP` | Indicates the transport layer protocol used by the server listening on the port. Valid values are `TCP` and `UDP`. |
 
 ### HealthProbe


### PR DESCRIPTION
Since now we have container port, and we should have a place to specify which port to expose in service.

fixes https://github.com/microsoft/hydra-spec/issues/120 
