### PR TITLE
component: add external resource definition

### DIFF
--- a/3.component_model.md
+++ b/3.component_model.md
@@ -112,6 +112,7 @@ The spec defines the constituent parts of a component.
 | `arch` | `string` | N | `amd64` | The CPU architecture required to host (all of) the component's containers (since containers share physical hardware with the underlying host). Possible values include:<ul><li>i386</li><li>amd64</li><li>arm</li><li>arm64</li></ul> |
 | `containers` | [`[]Container`](#container) | N | | The OCI container(s) that implement the component. |
 | `workloadSettings` | [`[]WorkloadSetting`](#workloadsetting) | N | | Declaration of non-container settings that should be passed to the workload runtime|
+| `resources` | [`[]ExternalResource`](#external-resource) | N | | Description of resources that the component depends on |
 
 All core workload types require `containers` and MUST return an error and cease processing if the `containers` section is empty. However, extended workload types may not require containers. Thus this field is marked optional.
 
@@ -249,6 +250,57 @@ Redis            | caching.hydra.io/v1.Redis     | Azure Redis
 ([Source](https://github.com/microsoft/hydra-spec/pull/123#issuecomment-491108730))
 
 Extended workload types MAY use the `containers` section of the component schematic, or MAY omit it. Extended workload types MAY use or omit the `workloadSettings` list in the component schematic. The purpose of the `workloadSetting` list is to provide authors of extended workload types with a location for specifying the configuration of that types.
+
+
+### External Resource
+
+Hydra allows an app developer to define external resources that the app depends on. Compared to _workload_ which defines how to run user application, _external resource_ defines some third party app, service, or item that user application wants to procure and use. It could be an essential managed service from cloud providers as well as in-cluster services managed by k8s operators. Examples include databases, tables in databases, a specific instance of database shared by many, object storage buckets, k8s resources (namespace, PV/PVC, ingress), DNS records, or even Hydra components.
+
+All external resources should be ready before starting the workload.
+
+Its definition is as follows:
+
+| Attribute | Type | Required | Default Value | Description |
+|-----------|------|----------|---------------|-------------|
+| `name` | `string` | Y | | The name of the resource |
+| `parameters` | `string` | N | | |
+
+Here is an example yaml:
+
+```yaml
+apiVersion: core.hydra.io/v1alpha1
+kind: ComponentSchematic
+metadata:
+  name: example-with-resources
+spec:
+  workloadType: core.hydra.io/v1alpha1.Service
+  resources:
+  - name: kube-namespace
+    parameters:
+    - name: name
+      type: string
+      description: the k8s namespace that should exist or be created before starting the component.
+  - name: object-storage-bucket
+    parameters:
+    - name: path
+      type: string
+      description: the path in the object storage
+  - name: mysql
+    parameters:
+    - name: output-secret
+      type: string
+      description: the name of the secret to store the output info, e.g. connection credentials
+  - name: dns
+    parameters:
+    - name: domain
+      description: the domain name for the DNS record
+  - name: load-balancer
+  - name: hydra-component
+    parameters:
+    - name: component-name
+      description: Another component to depend on
+```
+
 
 ### Container
 


### PR DESCRIPTION
This PR tries to address dependency problems of external resources. Specifically, cloud resources, k8s resources, even Hydra components that a user application depends on.

The justification for this new definition is that, in current spec, only extended workload touched it a little bit, but many resources aren't workload -- e.g. k8s namespace. Secondly, we want to model it as component's dependencies to make it component centric -- look at the example in the PR.

I add a flat layer of resources under component. Another option would be to define a new type called ResourceType -- In that way, we can have Resource decoupled and make common resource types like Database, Object Storage Bucket, etc.