### PR TITLE
configuration: wording refine

### DIFF
--- a/6.operational_configuration.md
+++ b/6.operational_configuration.md
@@ -118,7 +118,7 @@ In addition to being unique, the `instanceName` must follow these naming rules:
 > The instanceName segment is required and must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.
 
 ### Trait
-The scope section defines a instance of a trait and its parameter overrides.
+The trait section defines an instance of a trait and its properties (parameter overrides).
 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|


### PR DESCRIPTION
The wording has been copy&paste inappropriately.