### PR TITLE
ApplicationScope: add `network` core scope

### DIFF
--- a/4.application_scopes.md
+++ b/4.application_scopes.md
@@ -128,10 +128,6 @@ spec:
       description: The type of the gateway, options are 'public', 'nat'. Empty string means no gateway.
       type: string
       required: N
-    - name: auto-public-ip
-      description: It indicates if public IP address is automatically assigned to instances of components launched within the network.
-      type: boolean
-      default: false
 ```
 
 ### Health scope


### PR DESCRIPTION
With this PR, we can assign components to VPC.

Let me give an example that a user have two subnets, one public and one private:

```yaml
scopes:

- name: public-vpc
  type: core.../v1.NetworkScope
  properties:
  - name: network-id
    value: myNetwork
  - name: subnet-id
    value: public-subnet
  - name: gateway-type
    value: public

- name: private-vpc
  type: core.../v1.NetworkScope
  - name: network-id
    value: myNetwork
  - name: subnet-id
    value: private-subnet
  - name: gateway-type
    value: nat
```