### PR TITLE
component.configFile: replace `name` with `path`

### DIFF
--- a/3.component_model.md
+++ b/3.component_model.md
@@ -397,19 +397,19 @@ ConfigFile describes a path to a file available within the container, as well as
 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
-| `name` | `string` | Y || An absolute path within the container. |
+| `path` | `string` | Y || An absolute path within the container. |
 | `value` | `string` | N || The data to be written into the file at the specified path. If this is not supplied, `fromParam` must be supplied |
 | `fromParam` | `string` | N || The parameter whose value should be written into this file as a value |
 
-The `name` field must contain a path that abides by the pathing rules of the underlying operating system. If a relative path is given, implementations MUST assume the path is relative to the root directory of the container. Implementations MAY produce an error if using such a path would violate security measures or path layout requirements.
+The `path` field must contain a path that abides by the pathing rules of the underlying operating system. If a relative path is given, implementations MUST assume the path is relative to the root directory of the container. Implementations MAY produce an error if using such a path would violate security measures or path layout requirements.
 
 Example:
 
 ```yaml
 config:
-  - name: "/etc/access/default_user.txt"
+  - path: "/etc/access/default_user.txt"
     value: "admin"  # This is a literal value
-  - name: "/var/run/db-data"
+  - path: "/var/run/db-data"
     fromParam: "sourceData" # This will cause the value to be read from the parameter whose name is `sourceData`
 ```
 


### PR DESCRIPTION
The name field is not appropriate here. We should use path instead.