### PR TITLE
[WIP] Separating core, standard and extended types from traits, workload ty…

### DIFF
--- a/2.overview_and_terminology.md
+++ b/2.overview_and_terminology.md
@@ -1,6 +1,6 @@
 # 2. Overview and Terminology
 
-This section provides an overview of the specification and the terminology. It begins by identifying the organization roles that are involved in the process of running cloud native applications. From there, it lays out the specific terminology that is used throughout this document.
+This section provides an overview of the specification and the terminology. It begins by identifying the organization roles that are involved in the process of running cloud native applications. From there, it lays out terminology and core concepts that are used throughout this specification.
 
 ## Roles and Responsibilities
 
@@ -22,11 +22,11 @@ This specification proposes a model that defines cloud native applications as fo
 
 The application model defines the following:
 
- - _Components_ represents a runnable unit, together with a description (schematic).
- - _Workload types_ identify the different workloads that a component can execute.
- - _Traits_ are overlays that augment a component with additional operations-specific features. Traits represent operator concerns, not developer concerns.
- - _Application scopes_ represent application boundaries by grouping components with common properties or dependencies.
- - An _application configuration_ describes a set of component instances, their traits, and the application scopes in which they are placed, combined with configuration parameters and metadata.
+- _Components_ represents a runnable unit, together with a description (schematic).
+- _Workload types_ identify the different workloads that a component can execute.
+- _Traits_ are overlays that augment a component with additional operations-specific features. Traits represent operator concerns, not developer concerns.
+- _Application scopes_ represent application boundaries by grouping components with common properties or dependencies.
+- An _application configuration_ describes a set of component instances, their traits, and the application scopes in which they are placed, combined with configuration parameters and metadata.
 
 Thus, an _application_ is a collection of _components_ with a set of operational traits and scoped together into one or more application boundaries. 
 
@@ -42,7 +42,7 @@ This section describes the scheme.
 
 Group is a namespace for collecting several related kinds. Groups use a DNS naming convention. Example groups are:
 
-- components.hydra.io
+- core.hydra.io
 - functions.azure.com
 - my.dev
 
@@ -113,7 +113,7 @@ This form is not accepted as an alternative for the fully qualified version. It 
 The following terms are used throughout this specification.
 
 ### Component Schematics
- 
+
 __Component schematics__ permit __developers__ to declare the operational characteristics of the code they deliver _in infrastructure neutral terms_. Apart from not burdening developers with infrastructural concerns, this frees operators and runtimes to meet a component's infrastructural needs in whatever opinionated manner they see fit.
 
 A component schematic is composed of the following pieces of information:
@@ -141,6 +141,16 @@ A trait is described as:
 - Applies-to list: Enumeration of which workload types this trait applies to
 - Parameters: Configuration that may be specified in an application configuration
 
+### Application Scopes
+
+An application scope defines a set of common capabilities for a group of components. This may be functional capabilities, or simply a descriptive grouping. Defining a logical network boundary for communication, or health aggregation across components could be implemented using application scopes.
+
+An application scope is described as:
+
+- Metadata: Information about the application scope
+- Allow Component Overlap: Can components be part of multiple scopes of the same type
+- Parameters: Application scope configuration
+
 ### Application Configuration
 
 An application configuration is a resource that declares how an application (described as an application schematic and component schematics) can be instantiated and configured, including which parameter overrides and add-on traits.
@@ -151,6 +161,18 @@ An application configuration has the following parts:
 - Parameter Overrides: Values to supply to named parameters in the application or components
 - Trait configuration: A list of traits to enable, together with parameter overrides for each trait
 - Workload type settings: Overrides to workload type settings
+
+## Extending Hydra
+
+Workload types, traits and application scopes are all extension points for providing functionality in the Hydra model.
+
+Runtime implementations are welcome to bring their own set of workload types, traits and application scopes outside of the `hydra.io` namespace, but are encouraged to add portable functionality to the generally adopted `hydra.io` namespace group. The following three `hydra.io` groups are defined for all three types:
+
+- **`core.hydra.io`** These provide functionality that is necessary. Runtimes are REQUIRED to implement these traits as defined in this specification.
+
+- **`standard.hydra.io`** Runtimes are RECOMMENDED to use the standard definitions as defined in this specification. These types provide operational functionality that is commonly used by application operators and implemented by most runtimes. Runtimes are RECOMMENDED to use the standard type definitions as defined in this specification when providing equivalent operational functionality to those listed in the standard type definitions. In other words, if a runtime is implementing a type with behavior `foo` and a standard type definition for behavior `foo` exists, the runtime SHOULD use the standard `foo` type definition. Application operators that intend to maximize portability of their applications should use these type definitions when available. Although this does not _guarantee_ portability of an application, it is designed to increase portability across runtimes.
+
+- **`extension.hydra.io`** The specification allows a runtime to define its own set of types that might be unique to that runtime, but candidates for implementation in other runtimes. Types in the extension group can graduate to standard following wide adoption of the type.
 
 ## Representing Hydra Objects as Schematics
 
@@ -194,6 +216,7 @@ Metadata provides information about the contents of this object.
 The combination of group, kind, name must be unique. Two different kinds (for example, a Component and a Trait) may have the same name and not cause conflicts. Version is not a distinguishing factor.
 
 *Okay:* Each kind allows the name `foo`.
+
 ```yaml
 apiVersion: core.hydra.io/v1alpha1
 kind: Component

--- a/3.component_model.md
+++ b/3.component_model.md
@@ -91,19 +91,14 @@ Examples:
 
 - `core.hydra.io/v1alpha1.Singleton`: The group is `core.hydra`, meaning it is built-in. The version indicates that this is still an alpha version (`v1alpha1`). The kind is `Singleton`. This means the core singleton runtime must be used for this component.
 - `azure.com/v1.Function`: The group is `azure.com` (which is a vendor-specific implementation, and may not be present on all runtimes). The version is `v1`, which marks this as stable. The kind is `Function`, whose runtime implementation is the Azure Functions offering.
-- `streams.hydra.io/v1beta2.Kafka`: The group is `streams.hydra.io`, a hypothetical location where certain vendor-neutral extensions may exist. Version is `v1beta2`, indicating that it is moving toward stability. And the kind is `Kafka`.
-- `caching.hydra.io/v2.Redis`: The group is `caching.hydra.io`, version is `v2`, and the kind is `Redis`. This describes an implementation of a Redis cache.
+- `extension.hydra.io/v1beta2.Kafka`: The group is `extension.hydra.io`, the standard group for vendor-neutral extensions. Version is `v1beta2`, indicating that it is moving toward stability. And the kind is `Kafka`.
+- `extension.hydra.io/v2.Redis`: The group is `extension.hydra.io`, version is `v2`, and the kind is `Redis`. This describes an implementation of a Redis cache.
 
-> Group, Version, Kind is a [convention in Kubernetes](https://kubernetes.io/docs/reference/using-api/api-concepts/)
-
-There are two kinds of workload types:
-
-- Core workload types
-- Extended workload types
+> Group, Version, Kind is described [here](2.overview_and_terminology.md#group-version-and-kind) and is also a [convention in Kubernetes](https://kubernetes.io/docs/reference/using-api/api-concepts/)
 
 #### Core Workload Types
 
-The core workload types MUST be in the `core.hydra.io` group.
+The core workload types MUST be in the `core.hydra.io` [group](2.overview_and_terminology.md#extending-hydra).
 
 The core workload types MUST all be supported according to the definitions in this section by any runtime implementation of this specification.
 
@@ -115,77 +110,19 @@ Core workload types are focused on several distinguishing points:
 
 All core workload types are container-based, and assume that an implementation is capable of executing an OCI or Docker image as a container, and are capable of working with OCI registries.
 
-The following core workload types are defined by this specification:
+Core workload types are defined in the [core/workload-types](core/workload-types.md) document.
 
-|Name|Type|Service endpoint|Replicable|Daemonized|
-|-|-|-|-|-|
-|Service|core.hydra.io/v1alpha1.Service|Yes|Yes|Yes
-|Singleton Service|core.hydra.io/v1alpha1.SingletonService|Yes|No|Yes
-|Worker|core.hydra.io/v1alpha1.Worker|No|Yes|Yes
-|Singleton Worker|core.hydra.io/v1alpha1.SingletonWorker|No|No|Yes
-|Task|core.hydra.io/v1alpha1.Task|No|Yes|No
-|Singleton Task|core.hydra.io/v1alpha1.SingletonTask|No|No|No
+#### Standard and Extended Workload Types
 
-##### Service 
-Workload type name: `core.hydra.io/v1alpha1.Service`
+Standard and extended workload types are [_per runtime_](2.overview_and_terminology.md#extending-hydra), meaning that each runtime may implement its own set of standard extended workload types. In the present version of the spec, allowing user-defined extended workload types is _not supported_.
 
-A service is used for long-running, scalable workloads that have a network endpoint with a stable name to receive network traffic for the component as a whole. Common use cases include web applications and services that expose APIs. The Service workload type has the following characteristics:
- - Defines a container runtime where zero or more replicas of the same container may be run simultaneously. 
- - An application operator can increase or decrease the number of service replicas by applying and configuring traits when available. 
- - A service is daemonized. A runtime MUST attempt to restart replicas that exit regardless of error code.
- - A service has a network endpoint with an automatically assigned virtual IP address (VIP) and DNS name addressable within the network scope to which the component belongs.
-
-##### Singleton Service
-Workload type name: `core.hydra.io/v1alpha1.SingletonService`
-
-A singleton service is a special case of the Service workload type that is limited to at most one replica. The singleton service workload type as the following characteristics:
- - Defines a container runtime where at most one replica of the same container may be run at a time.  
- - A singleton service is daemonized. A runtime MUST attempt to restart the singleton replica if it exits regardless of error code.
- - A singleton service has a network endpoint with an automatically assigned virtual IP address (VIP) and DNS name addressable within the network scope to which the component belongs.
-
-##### Worker
-Workload type name: `core.hydra.io/v1alpha1.Worker`
-
-A worker is used for long-running, scalable workloads that do not have a service endpoint for network requests, aside from optional liveliness and readiness probe endpoints on individual replicas. Workers are typically used to pull from queues or provide other offline processing. The worker workload type has the following characteristics:
- - Defines a container runtime where zero or more replicas of the same container may be run simultaneously. 
- - An application operator can increase or decrease the number of worker replicas by applying and configuring traits when available.
- - A worker is daemonized. A runtime MUST attempt to restart replicas that exit regardless of error code.
-
-##### Singleton Worker
-Workload type name: `core.hydra.io/v1alpha1.SingletonWorker`
-
-A singleton worker is a special case of the worker workload type that is limited to at most one replica. The singleton worker workload type as the following characteristics:
- - Defines a container runtime where at most one replica of the same container may be run at a time.  
- - A singleton worker is daemonized. A runtime MUST attempt to restart the singleton replica if it exits regardless of error code.
-
-
-##### Task
-Workload type name: `core.hydra.io/v1alpha1.Task`
-
-A task is used to run code or a script to completion. Commonly used to run cron jobs or one-time highly parallelizable tasks that exit and free up resources upon completion. The task workload type has the following characteristics:
- - Defines a container runtime where zero or more replicas of the same container may be run simultaneously.
- - An application operator can increase or decrease the number of worker replicas by applying and configuring traits when available
-  - A task is non-daemonized. A runtime MUST NOT attempt to restart replicas that exit without an error code.
-
-##### Singleton Task
-Workload type name: `core.hydra.io/v1alpha1.SingletonTask`
-
-A singleton task is a special case of the task workload type that is limited to at most one replica. The singleton task workload type as the following characteristics:
- - Defines a container runtime where at most one replica of the same container may be run at a time.  
-  - A singleton task is non-daemonized. A runtime MUST NOT attempt to restart replicas that exit without an error code.
-
-
-Core workload descriptions MUST include a `container` section in the component schematic. Implementations of the core workload types MUST NOT require that a `workloadSetting` list be present in the component description (though it may allow that some settings are passed that way only if their default values are sufficient for running a workload).
-
-#### Extended Workload Types
-
-Extended workload types are _per runtime_, meaning that each runtime may define its own extended workload types beyond this specification. In the present version of the spec, allowing user-defined extended workload types is _not supported_.
+Standard and extended workload types are defined are defined in the [standard/workload_types](standard/workload_types.md) and [extended/workload_types](extended/workload_types.md) folders.
 
 Extended workload types MAY use the `containers` section of the component schematic, or MAY omit it. Extended workload types MAY use or omit the `workloadSettings` list in the component schematic. The purpose of the `workloadSetting` list is to provide authors of extended workload types with a location for specifying the configuration of that types.
 
 If an extended workload type is declared in a [component schematic](3.component_model.md), but is not provided by the current platform, the implementation MUST return an error and discontinue the operation.
 
-Guidance on further implementing extended workload types is covered in the non-normative [Appendix A: Extended Workload Types](10.appendix-extended-workload-types.md).
+Guidance on further implementing extended workload types is covered in the non-normative [Appendix A: Extended Workload Types](10.appendix_extended_workload_types.md).
 
 ### Container
 
@@ -472,20 +409,20 @@ to configure what kind of content the bot will tweet and the intervals at which
 it will do so.
 
 Because this component is stateless and horizontally scalable, it is described
-as a `ReplicableService`. The username, password, and address of the backend
+as a [**Service**](core/workload-types.md#service). The username, password, and address of the backend
 component are configurable.
 
 ```yaml
 apiVersion: core.hydra.io/v1alpha1
 kind: ComponentSchematic
 metadata:
-  name: replciatedservice
+  name: service
   annotations:
     version: v1.0.0
     description: >
       Sample component schematic that describes the administrative interface for our Twitter bot.
 spec:
-  workloadType: ReplicableService
+  workloadType: core.hydra.io/v1alpha1.Service
   osType: linux
   parameters:
   - name: username
@@ -538,7 +475,7 @@ configuration to disk as a JSON file.
 
 This component's design prevents it from scaling horizontally, so we should only
 have at most _one_ instance of it running. As such, this component is described
-as a `Singleton`. Connection details for the Twitter API are
+as a [**SingletonService**](core/workload-types.md#singleton-service). Connection details for the Twitter API are
 configurable. The component schematic also describes the file system location
 where the component persists end-user-defined configuration.
 
@@ -552,7 +489,7 @@ metadata:
     description: >
       Sample component schematic that describes the backend for our Twitter bot.
 spec:
-  workloadType: core.hydra.io/v1.SingletonService
+  workloadType: core.hydra.io/v1alpha1.SingletonService
   osType: linux
   parameters:
   - name: twitter-consumer-key
@@ -608,33 +545,6 @@ spec:
         path: /healthz
 ```
 
-#### Example: Extended Workload Type
-
-Imagine a service runtime that checks out code from a Git repository and executes it as an Azure function. This service might be used as follows:
-
-```yaml
-apiVersion: core.hydra.io/v1alpha1
-kind: ComponentSchematic
-metadata:
-  name: azurefunction
-  annotations:
-    version: v1.0.0
-    description: "Extended workflow example"
-spec:
-  workloadType: azure.com/v1.Function
-  parameters:
-  - name: github-token
-    description: GitHub API session key
-    type: string
-    required: true
-  workloadSettings:
-    - name: source
-      value: git://git.example.com/function/myfunction.git
-    - name: github_token
-      fromParam: github-token
-```
-
-
-| Previous Part        | Next Part           | 
-| ------------- |-------------| 
-|[2. Overview and Terminology](2.overview_and_terminology.md)    |  [4. Application Scopes](4.application_scopes.md)| 
+| Previous Part        | Next Part           |
+| ------------- |-------------|
+|[2. Overview and Terminology](2.overview_and_terminology.md)    |  [4. Application Scopes](4.application_scopes.md)|

--- a/4.application_scopes.md
+++ b/4.application_scopes.md
@@ -3,10 +3,11 @@
 Application scopes are used to group components together into logical applications by providing different forms of application boundaries with common group behaviors.
 
 Application scopes have the following general characteristics:
- - Application scopes SHOULD be used when defining behavior or metadata that is common to a group of component instances.
- - A component MAY be deployed into multiple application scopes of different types simultaneously. 
- - Application scope types MAY determine whether or not components can be deployed into multiple instances of the same application scope type simultaneously. 
- - Application scopes MAY be used as a connecting mechanism between groups of components and capabilities provided by infrastructure, such as networking, or external capabilities, such as identity providers.
+
+- Application scopes SHOULD be used when defining behavior or metadata that is common to a group of component instances.
+- A component MAY be deployed into multiple application scopes of different types simultaneously. 
+- Application scope types MAY determine whether or not components can be deployed into multiple instances of the same application scope type simultaneously. 
+- Application scopes MAY be used as a connecting mechanism between groups of components and capabilities provided by infrastructure, such as networking, or external capabilities, such as identity providers.
 
 The following diagram illustrates how components can be grouped into overlapping application scopes to create different application boundaries:
 
@@ -18,32 +19,32 @@ Components A, B, and C are deployed to the same health scope. The health scope w
 
 Component A is isolated in its own network scope from components B, C, and D. This allows the infrastructure operator to supply different SDN settings for different groups of components, such as more restricted inbound/outbound rules on back-end components.
 
-## Application scope types
-There are two kinds of application scope types:
- - Core application scope types
- - Extended application scope types
+## Categories of application scope types
+
+The application scope system is designed to serve as an extension point for runtime operational capability while also providing common, and in some cases, necessary operational functionality for components. Application scope types are grouped based on the standard namespace grouping defined [here](2.overview_and_terminology.md#extending-hydra).
+
+The implementation details of a application scopes is beyond the scope of this document.
 
 ### Core application scope types
+
 Core application scope types define grouping constructs for basic runtime behavior. They have the following characteristics:
 
- - Core application scope types MUST be in the `core.hydra.io` namespace.
- - Core application scope types MUST all be supported by any implementation of the specification. They may be implemented by any available feature in the platform, but they MUST be implemented according to the specification of each core application scope type.
- - Instances of core *workload* types MUST be deployed into an instance of each core application scope type. 
- - Runtimes MUST provide a default "root" application scope instance for each core application scope type.
- - Runtimes MUST deploy each component instances into default "root" application scope instances when an application configuration does not otherwise specify an application scope for a component instance.
+- Core application scope types MUST be in the `core.hydra.io` namespace.
+- Core application scope types MUST all be supported by any implementation of the specification. They may be implemented by any available feature in the platform, but they MUST be implemented according to the specification of each core application scope type.
+- Instances of core *workload* types MUST be deployed into an instance of each core application scope type.
+- Runtimes MUST provide a default "root" application scope instance for each core application scope type.
+- Runtimes MUST deploy each component instances into default "root" application scope instances when an application configuration does not otherwise specify an application scope for a component instance.
 
- The following core application scope types are defined by this specification:
+Core application scopes are defined are defined in the [core/application_scope](core/application_scope.md) document.
 
-| Name | Type | Description | 
-|-----------|------|----------|
-|Network|`core.hydra.io/v1alpha1.Network` | This scope groups components into a network subnet boundaries and defines the general runtime networking model. Network definitions, rules, and policies are described by the infrastructure's network or SDN.
-|Health|`core.hydra.io/v1alpha1.Health` | This scope groups components into an aggregate health group. The aggregate health of the constituent components within the group supplies information to upgrade and rollback mechanisms.  |
+### Standard and extended application scope types
 
-### Extended application scope types
+Standard and extended application scopes are recommended / optional per runtime, meaning that each runtime may choose which standard and extended application scopes are supported. In the present version of the spec, allowing user-defined extended application scope types is _not supported_.
 
-Extended application scopes are optional per runtime, meaning that each runtime may choose which extended scopes are supported. In this version of the spec, allowing user-defined extended application scope types is not supported.
+Standard and extended application scopes are defined are defined in the [standard/application_scopes](standard/application_scopes.md) and [extended/application_scopes](extended/application_scopes/readme.md) folders.
 
 ## Defining an application scope
+
 This section is normative because application scopes are an inspectable (and possibly shareable) part of the system. All scopes MUST be representable in the following format.
 
 Application scopes are defined with schematics like components and traits.
@@ -61,15 +62,15 @@ The following attributes are common across all schemata defined in this document
 
 ### Spec
 
-The spec defines the constituent parts of a scope. 
+The spec defines the constituent parts of a scope.
 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
-| `type` | `string` | Y | | Determines type of the application scope. The core types are defined [above](#core-application-scope-types) |
+| `type` | `string` | Y | | Determines type of the application scope. The core types are defined [here](core/application-scopes.md) |
 | `allowComponentOverlap` | `bool` | Y | | Determines whether a component is allowed to be in multiple instances of this scope type simultaneously. When false, the runtime implementation MUST produce an error and stop deployment if an attempt is made to place a component into more than one instance of this scope type simultaneously. |
 | `parameters` | [`[]Parameter`](#parameter) | N | | The scope's configuration options. |
 
-The `type` field defines the type name for this type. Examples may be found in the [Core Application Scope Types](#core-application-scope-types) above. Extended scope types MUST NOT be in the `core.hydra.io` namespace.  However, they must follow the [group, version, kind notation](2.overview_and_terminology.md). For example: `scopes.example.com/v1.ExtendedNetworkScope`
+The `type` field defines the type name for this type. Examples may be found in the [Core Application Scope Types](core/application-scopes.md). Other scope types MUST NOT be in the `core.hydra.io` namespace.  However, they must follow the [group, version, kind notation](2.overview_and_terminology.md).
 
 #### Parameter
 
@@ -86,162 +87,17 @@ The parameters that a scope exposes to operators.
 The `name` field allows Unicode letters, numbers and `_` and `-`. The `description` field allows those characters plus whitespace and punctuation characters.
 
 ## Deployment
+
 Application scope instances are defined and deployed in an application configuration. See [Application Configuration](6.application_configuration.md) for more information on deploying scopes.
 
-## Core scope type definitions
-The following core scope types are available:
-- network scope
-- health scope
+## Application Scope Definitions
 
-### Network scope
-The network scope groups components together and links them to a network or SDN. The network itself must be defined and operated by the infrastructure.
-
-The network scope may also be queried by traffic management traits to determine discoverability boundaries for a service mesh or API boundaries for API gateways.
-
-If no network scope is assigned, the platform MUST join the application to a default network. Within that default network, all components in the application configuration MUST be able to communicate to each other, and health probes MUST be able to contact any components who define health checking rules. The network joined, however, is platform-dependent. For example, cluster-based environments (such as Kubernetes) declare cluster-wide networks. Conversely, a truly serverless implementation may join the components to a network that only includes the components and the health checking probes.
-
-The network scope is defined by the following spec:
-
-```yaml
-apiVersion: core.hydra.io/v1alpha1
-kind: ApplicationScope
-metadata:
-  name: network
-  annotations:
-    version: v1.0.0
-    description: "network boundary that a group components reside in"
-spec:
-  type: core.hydra.io/v1.NetworkScope
-  allowComponentOverlap: false
-  parameters:
-    - name: network-id
-      description: The id of the network, e.g. vpc-id, VNet name.
-      type: string
-      required: Y
-    - name: subnet-id
-      description: The id of the subnet within the network.
-      type: string
-      required: Y
-    - name: internet-gateway-type
-      description: The type of the gateway, options are 'public', 'nat'. Empty string means no gateway.
-      type: string
-      required: N
-```
-
-### Health scope
-The health scope aggregates health states for components. Parameters of the health scope can be set to determine the percentage of components that must be unhealthy to consider the entire scope unhealthy.
-
-The health scope on its own does not take any action based on health status. It is only a group health aggregator that can be queried and used by other processes and parts of an application, such as:
- - Application upgrade traits can monitor the aggregate health of a health scope and decide when to initiate an automatic rollback.
- - Monitoring applications can monitor the aggregate health of a health scope to issue alerts.
-
-The health scope is defined by the following spec:
-
-```yaml
-apiVersion: core.hydra.io/v1alpha1
-kind: ApplicationScope
-metadata:
-  name: health
-  annotations:
-    version: v1.0.0
-    description: "aggregated health state for a group of components."
-spec:
-  type: core.hydra.io/v1alpha1.HealthScope
-  allowComponentOverlap: true
-  parameters:
-    - name: probe-method
-      description: The method to probe the components, e.g. 'httpGet'.
-      type: string
-      required: true
-    - name: probe-endpoint
-      description: The endpoint to probe from the components, e.g. '/v1/health'.
-      type: string
-      required: true
-    - name: probe-timeout
-      description: The amount of time in seconds to wait when receiving a response before marked failure.
-      type: integer
-      required: false
-    - name: probe-interval
-      description: The amount of time in seconds between probing tries.
-      type: integer
-      required: false
-    - name: failure-rate-threshold
-      description: If the rate of failure of total probe results is above this threshold, declared 'failed'.
-      type: double
-      required: false
-    - name: healthy-rate-threshold
-      description: If the rate of healthy of total probe results is above this threshold, declared 'healthy'.
-      type: double
-      required: false
-    - name: healthThresholdPercentage
-      description: The % of healthy components required to upgrade scope
-      type: double
-      required: false
-    - name: requiredHealthyComponents
-      description: Comma-separated list of names of the components required to be healthy for the scope to be health.
-      type: string
-      required: false
-```
-
-## Extended application scope type definitions
-The following extended scope types are available:
-- resource quota scope
-- identity scope
-
-### Resource Quota scope
-The resource quota scope sets resource quotas on a group of components. Resources include CPU, memory, storage, etc. Setting resource quotas for a scope applies across all components within the scope; in other words, the total resource consumption for all components within a scope cannot exceed a certain value.
-
-#### Example
-This is an example of a resource quota scope definition. 
-```yaml
-apiVersion: core.hydra.io/v1alpha1
-kind: ApplicationScope
-metadata:
-  name: myResourceQuotas
-  annotations:
-    version: v1.0.0
-    description: "The production configuration for Corp CMS"
-spec:
-  type: resources.hydra.io/v1.ResourceQuotaScope
-  allowComponentOverlap: false
-  parameters:
-    - name: CPU
-      description: maximum CPU to be consumed by this scope
-      type: double
-      required: Y
-    - name: Memory
-      description: maximum memory to be consumed by this scope
-      type: double
-      required: Y
-```
-
-### Identity scope
-
-The identity scope provides identities in components when authenticating to any service. The identities and its credentials are supplied and managed by an external identity provider.
-
-#### Example
-This is an example of a identity scope definition. 
-```yaml
-apiVersion: core.hydra.io/v1alpha1
-kind: ApplicationScope
-metadata:
-  name: myIdentityScope
-  annotations:
-    version: v1.0.0
-    description: "The production configuration for Corp CMS"
-spec:
-  type: identity.hydra.io/v1.IdentityScope
-  allowComponentOverlap: true
-  parameters:
-    - name: IdentityProvider
-      description: the provider of identity for the scope
-      type: string
-      required: Y
-```
+- Core application scopes are defined in the [core/application-scopes.md](core/application-scopes.md) document.
+- Standard application scopes are defined in the [standard/application-scopes.md](standard/application-scopes.md) document.
+- Extended application scopes are defined in the [extended/application-scopes/readme.md](extended/application-scopes/readme.md) document.
 
 [scope-diagram-1]: assets/scopes-diagram-1.png
 
-| Previous Part        | Next Part           | 
+| Previous Part        | Next Part           |
 | ------------- |-------------|
 | [3. The Component Model](3.component_model.md)     | [5. Traits](5.traits.md) |
-

--- a/5.traits.md
+++ b/5.traits.md
@@ -4,11 +4,11 @@ A _trait_ is a discretionary runtime overlay that augments a component workload 
 
 The _traits system_ is defined in this specification as the way a runtime applies and manages operational behaviors to instances of components through traits.
 
-Runtime implementations of the specification MUST provide the traits system for attaching operational behaviors to instances of components. 
+Runtime implementations of the specification MUST provide the traits system for attaching operational behaviors to instances of components.
 
-## Traits system rules and characteristics 
+## Traits system rules and characteristics
 
-Traits are applied to component instances in the [application configuration](6.application_configuration.md). 
+Traits are applied to component instances in the [application configuration](6.application_configuration.md).
 
 Traits should be applied into the runtime at installation/upgrade time. Traits should not be checked "lazily", but should be checked when the trait-holding components are created.
 
@@ -31,15 +31,9 @@ Any trait that is made available in a runtime MUST be implemented for that runti
 
 ## Categories of traits
 
-The  traits system is designed to serve as an extension point for runtime operational capability while also providing common, and in some cases, necessary operational functionality for components.
+The traits system is designed to serve as an extension point for runtime operational capability while also providing common, and in some cases, necessary operational functionality for components.
 
-The implementation details of a trait is beyond the scope of this document. However, to allow runtimes to implement arbitrary traits while maintaining a degree commonality for application portability across runtimes, traits are categorized in the following way:
-
- - **Core traits.** This specification defines a set of trait definitions with type names in the `core.hydra.io` group. These traits provide operational functionality that is necessary for the operation of certain workload types and component features. Runtimes are REQUIRED to implement these traits as defined in this specification.
-
- - **Standard traits.** The specification defines a set of trait definitions with type names in the `standard.hydra.io` group. These traits provide operational functionality that is commonly used by application operators and implemented by most runtimes. Runtimes are RECOMMENDED to use the standard trait definitions as defined in this specification when providing equivalent operational functionality to those listed in the standard trait definitions. In other words, if a runtime is implementing trait with behavior `foo` and a standard trait definition for behavior `foo` exists, the runtime SHOULD use the standard `foo` trait definition. Application operators that intend to maximize portability of their applications should use these trait definitions when available. Although this does not _guarantee_ portability of an application, it is designed to increase portability across runtimes.
-
- - **Extension traits.** The specification allows a runtime to define its own set of trait definitions that are unique to that runtime in addition to those defined by core and standard traits. A runtime can choose to implement any set of traits in this category with any definition. Extension trait type names MUST NOT be in the `core.hydra.io` or `standard.hydra.io` groups.
+The implementation details of a trait is beyond the scope of this document. However, to allow runtimes to implement arbitrary traits while maintaining a degree commonality for application portability across runtimes, traits are categorized using the [standard grouping](2.overview_and_terminology.md#extending-hydra) in the `hydra.io` namespace.
 
 ## Trait characteristics
 
@@ -66,7 +60,7 @@ The top-level attributes of a trait define its metadata, version, kind, and spec
 | `metadata` | [`Metadata`](2.overview_and_terminology.md#metadata) | Y | | Trait metadata. |
 | `spec`| [`Spec`](#spec) | Y || A specification for trait attributes. |
 
-### Spec
+#### Spec
 
 The specification defines two major things: The list of workload types to which this trait applies, and the list of configurable parameters on this trait.
 
@@ -75,7 +69,7 @@ The specification defines two major things: The list of workload types to which 
 | `appliesTo` | `[]string` | Y | `["*"]` | The list of workload types that this trait applies to. `"*"` means _any workload type_. A trait must apply to at least one workload type. This attribute must contain at least one value. An empty array is invalid for this attribute. |
 | `properties` | [`JSON Schema`](#properties) | Y | | A [JSON schema](https://json-schema.org/) expressed as inline YAML for the trait's configuration options. |
 
-### Properties
+##### Properties
 
 A properties object is an object whose structure is determined by the trait property schema. It may be a simple value, or it may be a complex object.
 
@@ -83,78 +77,12 @@ The value of the properties field in a trait definition is a [JSON schema](https
 
 For example, if a trait defines a schema for properties that requires an array of integers with at least one member, the properties object is expected to be an array of integers with at least one member. During validation of the properties object, the trait's property schema will be applied.
 
-## Core traits
+## Traits definitions
 
-### Manual Scaler
+- Core traits are defined in the [core/traits.md](core/traits.md) document.
+- Standard traits are defined in the [standard/traits.md](standard/traits.md) document.
+- Extended traits are defined in the [extended/traits/readme.md](extended/traits/readme.md) document.
 
-This trait definition allows operators to manually scale the number of replicas for workload types that allow scaling operations.
-
-#### Applicable workload types 
-
- - `core.hydra.io/v1alpha1.Service`
- - `core.hydra.io/v1alpha1.Worker`
- - `core.hydra.io/v1alpha1.Task`
-
-#### Properties
-
-| Attribute | Type | Required | Default Value | Description |
-|-----------|------|----------|---------------|-------------|
-| `replicaCount` | `integer` | Y | `0` | The target number of replicas to create for a given component instance. |
-
-#### Spec
-
-```yaml
-apiVersion: core.hydra.io/v1alpha1
-kind: Trait
-metadata:
-  name: ManualScaler
-  annotations:
-    version: v1.0.0
-    description: "Allow operators to manually scale a workloads that allow multiple replicas."
-spec:
-  appliesTo:
-    - core.hydra.io/v1alpha1.Service
-    - core.hydra.io/v1alpha1.Worker
-    - core.hydra.io/v1alpha1.Task
-  properties:
-    type: object
-    properties:
-      replicaCount:
-        description: the target number of replicas to scale a component to.
-        type: integer
-        minimum: 0
-      required:
-        - replicaCount
-    
-```
-
-#### Usage examples
-
-The following snippet from an application configuration shows how the manual scaler trait is applied and configured for a component. In this example, it is assumed component `frontend` has a workload type of `core.hydra.io/v1alpha1.Service`.
-
-```yaml
-apiVersion: core.hydra.io/v1alpha1
-kind: ApplicationConfiguration
-metadata:
-  name: custom-single-app
-  annotations:
-    version: v1.0.0
-    description: "Customized version of single-app"
-spec:
-  variables:
-  components:
-    - componentName: frontend
-      instanceName: web-front-end
-      parameterValues:
-      traits:
-        - name: ManualScaler
-          properties:
-            replicaCount: 5
-```
-
-This example illustrates using the manual scaler trait to manually scale a component by specifying the number of replicas the runtime should create. This trait has only one attribute in its properties: `replicaCount`. This takes an integer, and a value is required for this trait to be successfully applied. If, for example, an application configuration used this trait but did not provide the `replicaCount`, the system would reject the application configuration.
-
-
-| Previous Part        | Next Part           | 
+| Previous Part        | Next Part           |
 | ------------- |-------------|
 | [4. Application Scopes](4.application_scopes.md) | [6. Application Configuration](6.application_configuration.md) |

--- a/7.workload_types.md
+++ b/7.workload_types.md
@@ -4,7 +4,7 @@ Using `workloadType` is covered in section [3. Component Model](3.component_mode
 
 Workload types are provided by the platform (just as traits are) so that users may inspect the platform and learn what workload types are available for use. Workload types are not extensible to platform users (only to platform operators). Thus, platform users MUST NOT be allowed to create new workload types.
 
-#### Top-Level Attributes
+## Top-Level Attributes
 
 These attributes provide top-level information about the workload type.
 
@@ -15,11 +15,11 @@ These attributes provide top-level information about the workload type.
 | `metadata` | [`Metadata`](#metadata) | Y | | WorkloadType metadata. |
 | `spec`| [`Spec`](#spec) | Y || A container for exposing the workload type definition. |
 
-#### Metadata
+### Metadata
 
 The metadata describes this workload type. The metadata section is defined in [Section 3](3.component_model.md#metadata).
 
-#### Spec
+### Spec
 
 The specification describes how to declare that a component is bound to a workload type. In addition, it exposes which settings are configurable on the underlying workload runtime.
 
@@ -59,7 +59,12 @@ Settings describe which pieces of a workload type are configurable.
 
 The `name` field allows Unicode letters, numbers and `_` and `-`. The `description` field allows those characters plus whitespace and punctuation characters.
 
+For a list of workload type specifications see:
 
-| Previous        | Next           | 
+- [Core](core/workload-types.md)
+- [Standard](standard/workload_types.md)
+- [Extended](extended/workload_types/readme.md)
+
+| Previous        | Next           |
 | ------------- |-------------|
 | [6. Application Configuration](6.application_configuration.md) | [8. Practical Considerations](8.practical_considerations.md) |

--- a/core/application_scope.md
+++ b/core/application_scope.md
@@ -1,0 +1,105 @@
+# Core Application Scopes
+
+The following core application scopes are defined by this specification:
+
+| Name | Type | Description |
+|-----------|------|----------|
+|[Network](#network)|core.hydra.io/v1alpha1.Network | This scope groups components into a network subnet boundaries and defines the general runtime networking model. Network definitions, rules, and policies are described by the infrastructure's network or SDN.
+|[Health](#health)|core.hydra.io/v1alpha1.Health | This scope groups components into an aggregate health group. The aggregate health of the constituent components within the group supplies information to upgrade and rollback mechanisms.  |
+
+## Network
+
+Application scope name: `core.hydra.io/v1alpha1.Network`
+
+The network scope groups components together and links them to a network or SDN. The network itself must be defined and operated by the infrastructure.
+
+The network scope may also be queried by traffic management traits to determine discoverability boundaries for a service mesh or API boundaries for API gateways.
+
+If no network scope is assigned, the platform MUST join the application to a default network. Within that default network, all components in the application configuration MUST be able to communicate to each other, and health probes MUST be able to contact any components who define health checking rules. The network joined, however, is platform-dependent. For example, cluster-based environments (such as Kubernetes) declare cluster-wide networks. Conversely, a truly serverless implementation may join the components to a network that only includes the components and the health checking probes.
+
+The network scope is defined by the following spec:
+
+```yaml
+apiVersion: core.hydra.io/v1alpha1
+kind: ApplicationScope
+metadata:
+  name: network
+  annotations:
+    version: v1.0.0
+    description: "network boundary that a group components reside in"
+spec:
+  type: core.hydra.io/v1.NetworkScope
+  allowComponentOverlap: false
+  parameters:
+    - name: network-id
+      description: The id of the network, e.g. vpc-id, VNet name.
+      type: string
+      required: Y
+    - name: subnet-id
+      description: The id of the subnet within the network.
+      type: string
+      required: Y
+    - name: internet-gateway-type
+      description: The type of the gateway, options are 'public', 'nat'. Empty string means no gateway.
+      type: string
+      required: N
+```
+
+## Health
+
+Application scope name: `core.hydra.io/v1alpha1.Health`
+
+The health scope aggregates health states for components. Parameters of the health scope can be set to determine the percentage of components that must be unhealthy to consider the entire scope unhealthy.
+
+The health scope on its own does not take any action based on health status. It is only a group health aggregator that can be queried and used by other processes and parts of an application, such as:
+
+- Application upgrade traits can monitor the aggregate health of a health scope and decide when to initiate an automatic rollback.
+- Monitoring applications can monitor the aggregate health of a health scope to issue alerts.
+
+The health scope is defined by the following spec:
+
+```yaml
+apiVersion: core.hydra.io/v1alpha1
+kind: ApplicationScope
+metadata:
+  name: health
+  annotations:
+    version: v1.0.0
+    description: "aggregated health state for a group of components."
+spec:
+  type: core.hydra.io/v1alpha1.HealthScope
+  allowComponentOverlap: true
+  parameters:
+    - name: probe-method
+      description: The method to probe the components, e.g. 'httpGet'.
+      type: string
+      required: true
+    - name: probe-endpoint
+      description: The endpoint to probe from the components, e.g. '/v1/health'.
+      type: string
+      required: true
+    - name: probe-timeout
+      description: The amount of time in seconds to wait when receiving a response before marked failure.
+      type: integer
+      required: false
+    - name: probe-interval
+      description: The amount of time in seconds between probing tries.
+      type: integer
+      required: false
+    - name: failure-rate-threshold
+      description: If the rate of failure of total probe results is above this threshold, declared 'failed'.
+      type: double
+      required: false
+    - name: healthy-rate-threshold
+      description: If the rate of healthy of total probe results is above this threshold, declared 'healthy'.
+      type: double
+      required: false
+    - name: healthThresholdPercentage
+      description: The % of healthy components required to upgrade scope
+      type: double
+      required: false
+    - name: requiredHealthyComponents
+      description: Comma-separated list of names of the components required to be healthy for the scope to be health.
+      type: string
+      required: false
+```

--- a/core/traits.md
+++ b/core/traits.md
@@ -1,0 +1,75 @@
+# Core Traits
+
+The following core traits are defined by this specification:
+
+| Name | Type | Description |
+|-----------|------|----------|
+| [Manual Scaler](#manual-scaler) | core.hydra.io/v1alpha1.ManualScaler | This trait definition allows operators to manually scale the number of replicas for workload types that allow scaling operations. |
+
+## Manual Scaler
+
+This trait definition allows operators to manually scale the number of replicas for workload types that allow scaling operations.
+
+### Applicable workload types
+
+- `core.hydra.io/v1alpha1.Service`
+- `core.hydra.io/v1alpha1.Worker`
+- `core.hydra.io/v1alpha1.Task`
+
+### Properties
+
+| Attribute | Type | Required | Default Value | Description |
+|-----------|------|----------|---------------|-------------|
+| `replicaCount` | `integer` | Y | `0` | The target number of replicas to create for a given component instance. |
+
+### Spec
+
+```yaml
+apiVersion: core.hydra.io/v1alpha1
+kind: Trait
+metadata:
+  name: ManualScaler
+  annotations:
+    version: v1.0.0
+    description: "Allow operators to manually scale a workloads that allow multiple replicas."
+spec:
+  appliesTo:
+    - core.hydra.io/v1alpha1.Service
+    - core.hydra.io/v1alpha1.Worker
+    - core.hydra.io/v1alpha1.Task
+  properties:
+    type: object
+    properties:
+      replicaCount:
+        description: the target number of replicas to scale a component to.
+        type: integer
+        minimum: 0
+      required:
+        - replicaCount
+```
+
+### Usage examples
+
+The following snippet from an application configuration shows how the manual scaler trait is applied and configured for a component. In this example, it is assumed component `frontend` has a workload type of `core.hydra.io/v1alpha1.Service`.
+
+```yaml
+apiVersion: core.hydra.io/v1alpha1
+kind: ApplicationConfiguration
+metadata:
+  name: custom-single-app
+  annotations:
+    version: v1.0.0
+    description: "Customized version of single-app"
+spec:
+  variables:
+  components:
+    - componentName: frontend
+      instanceName: web-front-end
+      parameterValues:
+      traits:
+        - name: core.hydra.io/v1alpha1.ManualScaler
+          properties:
+            replicaCount: 5
+```
+
+This example illustrates using the manual scaler trait to manually scale a component by specifying the number of replicas the runtime should create. This trait has only one attribute in its properties: `replicaCount`. This takes an integer, and a value is required for this trait to be successfully applied. If, for example, an application configuration used this trait but did not provide the `replicaCount`, the system would reject the application configuration.

--- a/core/workload_types.md
+++ b/core/workload_types.md
@@ -1,0 +1,73 @@
+# Core Workload Types
+
+The following core workload types are defined by this specification:
+
+|Name|Type|Service endpoint|Replicable|Daemonized|
+|-|-|-|-|-|
+|[Service](#service)|core.hydra.io/v1alpha1.Service|Yes|Yes|Yes
+|[Singleton Service](#singleton-service)|core.hydra.io/v1alpha1.SingletonService|Yes|No|Yes
+|[Worker](#worker)|core.hydra.io/v1alpha1.Worker|No|Yes|Yes
+|[Singleton Worker](#singleton-worker)|core.hydra.io/v1alpha1.SingletonWorker|No|No|Yes
+|[Task](#task)|core.hydra.io/v1alpha1.Task|No|Yes|No
+|[Singleton Task](#singleton-task)|core.hydra.io/v1alpha1.SingletonTask|No|No|No
+
+## Service
+
+Workload type name: `core.hydra.io/v1alpha1.Service`
+
+A service is used for long-running, scalable workloads that have a network endpoint with a stable name to receive network traffic for the component as a whole. Common use cases include web applications and services that expose APIs. The Service workload type has the following characteristics:
+
+- Defines a container runtime where zero or more replicas of the same container may be run simultaneously.
+- An application operator can increase or decrease the number of service replicas by applying and configuring traits when available.
+- A service is daemonized. A runtime MUST attempt to restart replicas that exit regardless of error code.
+- A service has a network endpoint with an automatically assigned virtual IP address (VIP) and DNS name addressable within the network scope to which the component belongs.
+
+## Singleton Service
+
+Workload type name: `core.hydra.io/v1alpha1.SingletonService`
+
+A singleton service is a special case of the Service workload type that is limited to at most one replica. The singleton service workload type as the following characteristics:
+
+- Defines a container runtime where at most one replica of the same container may be run at a time.  
+- A singleton service is daemonized. A runtime MUST attempt to restart the singleton replica if it exits regardless of error code.
+- A singleton service has a network endpoint with an automatically assigned virtual IP address (VIP) and DNS name addressable within the network scope to which the component belongs.
+
+## Worker
+
+Workload type name: `core.hydra.io/v1alpha1.Worker`
+
+A worker is used for long-running, scalable workloads that do not have a service endpoint for network requests, aside from optional liveliness and readiness probe endpoints on individual replicas. Workers are typically used to pull from queues or provide other offline processing. The worker workload type has the following characteristics:
+
+- Defines a container runtime where zero or more replicas of the same container may be run simultaneously.
+- An application operator can increase or decrease the number of worker replicas by applying and configuring traits when available.
+- A worker is daemonized. A runtime MUST attempt to restart replicas that exit regardless of error code.
+
+## Singleton Worker
+
+Workload type name: `core.hydra.io/v1alpha1.SingletonWorker`
+
+A singleton worker is a special case of the worker workload type that is limited to at most one replica. The singleton worker workload type as the following characteristics:
+
+- Defines a container runtime where at most one replica of the same container may be run at a time.  
+- A singleton worker is daemonized. A runtime MUST attempt to restart the singleton replica if it exits regardless of error code.
+
+## Task
+
+Workload type name: `core.hydra.io/v1alpha1.Task`
+
+A task is used to run code or a script to completion. Commonly used to run cron jobs or one-time highly parallelizable tasks that exit and free up resources upon completion. The task workload type has the following characteristics:
+
+- Defines a container runtime where zero or more replicas of the same container may be run simultaneously.
+- An application operator can increase or decrease the number of worker replicas by applying and configuring traits when available
+- A task is non-daemonized. A runtime MUST NOT attempt to restart replicas that exit without an error code.
+
+## Singleton Task
+
+Workload type name: `core.hydra.io/v1alpha1.SingletonTask`
+
+A singleton task is a special case of the task workload type that is limited to at most one replica. The singleton task workload type as the following characteristics:
+
+- Defines a container runtime where at most one replica of the same container may be run at a time.  
+- A singleton task is non-daemonized. A runtime MUST NOT attempt to restart replicas that exit without an error code.
+
+Core workload descriptions MUST include a `container` section in the component schematic. Implementations of the core workload types MUST NOT require that a `workloadSetting` list be present in the component description (though it may allow that some settings are passed that way only if their default values are sufficient for running a workload).

--- a/extended/application_scopes/README.md
+++ b/extended/application_scopes/README.md
@@ -1,0 +1,10 @@
+# Extended Application Scopes
+
+This folder contains specifications for application scopes in the `extended.hydra.core` namespace. For more information about the namespaces see [here](../../2.overview_and_terminology.md#extending-hydra).
+
+The following extended application scopes exists:
+
+| Name | Type | Description |
+|-----------|------|----------|
+|[Identity](identity.md)| extension.hydra.io/v1.IdentityScope | The identity scope provides identities in components when authenticating to any service. |
+|[Resource Quota](resource-quota.md)| extension.hydra.io/v1.ResourceQuotaScope | The resource quota scope sets resource quotas on a group of components. |

--- a/extended/application_scopes/identity.md
+++ b/extended/application_scopes/identity.md
@@ -1,0 +1,25 @@
+# Identity scope
+
+The identity scope provides identities in components when authenticating to any service. The identities and its credentials are supplied and managed by an external identity provider.
+
+## Example
+
+This is an example of a identity scope definition.
+
+```yaml
+apiVersion: core.hydra.io/v1alpha1
+kind: ApplicationScope
+metadata:
+  name: myIdentityScope
+  annotations:
+    version: v1.0.0
+    description: "The production configuration for Corp CMS"
+spec:
+  type: extension.hydra.io/v1.IdentityScope
+  allowComponentOverlap: true
+  parameters:
+    - name: IdentityProvider
+      description: the provider of identity for the scope
+      type: string
+      required: Y
+```

--- a/extended/application_scopes/resource-quota.md
+++ b/extended/application_scopes/resource-quota.md
@@ -1,0 +1,29 @@
+# Resource Quota scope
+
+The resource quota scope sets resource quotas on a group of components. Resources include CPU, memory, storage, etc. Setting resource quotas for a scope applies across all components within the scope; in other words, the total resource consumption for all components within a scope cannot exceed a certain value.
+
+## Example
+
+This is an example of a resource quota scope definition.
+
+```yaml
+apiVersion: core.hydra.io/v1alpha1
+kind: ApplicationScope
+metadata:
+  name: myResourceQuotas
+  annotations:
+    version: v1.0.0
+    description: "The production configuration for Corp CMS"
+spec:
+  type: extension.hydra.io/v1.ResourceQuotaScope
+  allowComponentOverlap: false
+  parameters:
+    - name: CPU
+      description: maximum CPU to be consumed by this scope
+      type: double
+      required: Y
+    - name: Memory
+      description: maximum memory to be consumed by this scope
+      type: double
+      required: Y
+```

--- a/extended/traits/README.md
+++ b/extended/traits/README.md
@@ -1,0 +1,8 @@
+# Extended Traits
+
+This folder contains specifications for traits in the `extended.hydra.core` namespace. For more information about the namespaces see [here](../../2.overview_and_terminology.md#extending-hydra).
+
+The following extended trait types exists:
+
+| Name | Type | Description |
+|-----------|------|----------|

--- a/extended/workload_types/README.md
+++ b/extended/workload_types/README.md
@@ -1,0 +1,8 @@
+# Extended Workload Types
+
+This folder contains specifications for workload types in the `extended.hydra.core` namespace. For more information about the namespaces see [here](../../2.overview_and_terminology.md#extending-hydra).
+
+The following extended workload types exists:
+
+| Name | Type | Description |
+|-----------|------|----------|

--- a/standard/application_scope_types.md
+++ b/standard/application_scope_types.md
@@ -1,0 +1,8 @@
+# Standard Application Scopes
+
+This folder contains specifications for application scopes in the `standard.hydra.core` namespace. For more information about the namespaces see [here](../../2.overview_and_terminology.md#extending-hydra).
+
+The following standard application scopes exists:
+
+| Name | Type | Description |
+|-----------|------|----------|

--- a/standard/traits.md
+++ b/standard/traits.md
@@ -1,0 +1,8 @@
+# Standard Traits
+
+This folder contains specifications for traits in the `standard.hydra.core` namespace. For more information about the namespaces see [here](../../2.overview_and_terminology.md#extending-hydra).
+
+The following standard traits exists:
+
+| Name | Type | Description |
+|-----------|------|----------|

--- a/standard/traits/README
+++ b/standard/traits/README
@@ -1,1 +1,0 @@
-Placeholder for standard traits.

--- a/standard/workload_types.md
+++ b/standard/workload_types.md
@@ -1,0 +1,8 @@
+# Standard Workload Types
+
+This folder contains specifications for workload types in the `standard.hydra.core` namespace. For more information about the namespaces see [here](../../2.overview_and_terminology.md#extending-hydra).
+
+The following standard workload types exists:
+
+| Name | Type | Description |
+|-----------|------|----------|


### PR DESCRIPTION
Fixes #143 

Note this is not just app scopes, but also traits and workload types to setup the repo to easily identify core, standard and extended.

Here's in overview what I ended up doing:
- Moved the core.hydra.io, standard.hydra.io and extended.hydra.io names, which were defined in traits to the overview doc, so it could apply to workload types and application scopes as well.
- Moved the definition of all types already defined in to folders for core, standard and extended - mainly for readability and maintainability (I think it helped a lot :-))
- Core and standard are just one doc, extended I made folders to accommodate for an explosion of specs, eventually...
- Fixing references...

A few questions that arose from this:
Q1. Should Identity and Resource application scopes move to standard - or are they mainly examples? They are currently defined as extended application scopes, but that seems silly at this point, as we've said we don't support extended types in this version of the spec. I vote that we move them to standard or simply delete them if no-one has plans to implement them.

Q2. Do we want to host extended types specifications in this repo? I ended up describing how extensions are for general purpose that could eventually graduate to standard, but thinking as to how etc. is not done yet.

@macolso 