### PR TITLE
AppConfig: fix the `traits` definition

### DIFF
--- a/6.application_configuration.md
+++ b/6.application_configuration.md
@@ -119,8 +119,7 @@ The trait section defines an instance of a trait and its properties (parameter o
 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
-| `name` | `string` | Y | | The name of the trait instance. Must be unique to the deployment environment. |
-| `type` | `string` | Y | | The fully-qualified GROUP/VERSION.KIND name of the trait. |
+| `name` | `string` | Y | | The name of the Trait. This is used to reference to the definition/schema of the Trait. For one type of trait, there could be only one config/deploy in one component. |
 | `properties` | [`Properties`](#properties) | N | | Overrides of parameters that are exposed by the trait type defined in `type`. |
 
 > The name field is required and must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.
@@ -178,8 +177,7 @@ spec:
         - name: ANOTHER_PARAMETER
           value: "[fromVariable(VAR_NAME)]"
       traits:
-        - name: my-app-ingress
-          type: core.hydra.io/v1alpha1.ingress
+        - name: Ingress
           properties:
             CUSTOM_OBJECT:
               DATA: "[fromVariable(VAR_NAME)]"
@@ -297,7 +295,7 @@ $ hyctl trait-list
 ╚════════════╧═════════╧═════════════════════════════════════════════╝
 ```
 
-Here is how the previous application configuration looks with an `ingress` trait attached to the front-end component:
+Here is how the previous application configuration looks with an `Ingress` trait attached to the front-end component:
 
 ```yaml
 apiVersion: core.hydra.io/v1alpha1
@@ -320,8 +318,7 @@ spec:
         - name: message
           value: "[fromVariable(message)]"
       traits:
-        - name: app-ingress
-          type: core.hydra.io/v1alpha1.Ingress
+        - name: Ingress
           properties:
             - name: host
               from: domainName
@@ -370,8 +367,7 @@ spec:
         - name: message
           value: "[fromVariable(networkName)]"
       traits:
-        - name: app-ingress
-          type: core.hydra.io/v1alpha1.Ingress
+        - name: Ingress
           properties:
             - name: host
               value: "[fromVaraible(domainName)]"


### PR DESCRIPTION
- trait schema will be referenced by its name. There will be no type field.
- explicitly states that only one config/deploy of one trait in one component

We have discussed this in [previous issue](https://github.com/microsoft/hydra-spec/pull/44) and sync-up meetings. This basically writes down the agreed-on approach and fix the definition.