### PR TITLE
Renaming Service workload type to Server

### DIFF
--- a/2.overview_and_terminology.md
+++ b/2.overview_and_terminology.md
@@ -168,7 +168,7 @@ kind: ComponentSchematic            ## Kind
 metadata:                           ## Metadata
   name: nginx-replicated
 spec:                               ## Specification
-  workloadType: core.hydra.io/v1alpha1.ReplicatedService
+  workloadType: core.hydra.io/v1alpha1.Server
   os: linux
   containers:
     - name: server

--- a/3.component_model.md
+++ b/3.component_model.md
@@ -119,29 +119,29 @@ The following core workload types are defined by this specification:
 
 |Name|Type|Service endpoint|Replicable|Daemonized|
 |-|-|-|-|-|
-|Service|core.hydra.io/v1alpha1.Service|Yes|Yes|Yes
-|Singleton Service|core.hydra.io/v1alpha1.SingletonService|Yes|No|Yes
+|Server|core.hydra.io/v1alpha1.Server|Yes|Yes|Yes
+|Singleton Server|core.hydra.io/v1alpha1.SingletonServer|Yes|No|Yes
 |Worker|core.hydra.io/v1alpha1.Worker|No|Yes|Yes
 |Singleton Worker|core.hydra.io/v1alpha1.SingletonWorker|No|No|Yes
 |Task|core.hydra.io/v1alpha1.Task|No|Yes|No
 |Singleton Task|core.hydra.io/v1alpha1.SingletonTask|No|No|No
 
-##### Service 
-Workload type name: `core.hydra.io/v1alpha1.Service`
+##### Server 
+Workload type name: `core.hydra.io/v1alpha1.Server`
 
-A service is used for long-running, scalable workloads that have a network endpoint with a stable name to receive network traffic for the component as a whole. Common use cases include web applications and services that expose APIs. The Service workload type has the following characteristics:
+A Server is used for long-running, scalable workloads that have a network endpoint with a stable name to receive network traffic for the component as a whole. Common use cases include web applications and services that expose APIs. The Server workload type has the following characteristics:
  - Defines a container runtime where zero or more replicas of the same container may be run simultaneously. 
- - An application operator can increase or decrease the number of service replicas by applying and configuring traits when available. 
- - A service is daemonized. A runtime MUST attempt to restart replicas that exit regardless of error code.
- - A service has a network endpoint with an automatically assigned virtual IP address (VIP) and DNS name addressable within the network scope to which the component belongs.
+ - An application operator can increase or decrease the number of component replicas by applying and configuring traits when available. 
+ - A Server is daemonized. A runtime MUST attempt to restart replicas that exit regardless of error code.
+ - A Server has a network endpoint with an automatically assigned virtual IP address (VIP) and DNS name addressable within the network scope to which the component belongs.
 
-##### Singleton Service
-Workload type name: `core.hydra.io/v1alpha1.SingletonService`
+##### Singleton Server
+Workload type name: `core.hydra.io/v1alpha1.SingletonServer`
 
-A singleton service is a special case of the Service workload type that is limited to at most one replica. The singleton service workload type as the following characteristics:
+A Singleton Server is a special case of the Server workload type that is limited to at most one replica. The Singleton Server workload type as the following characteristics:
  - Defines a container runtime where at most one replica of the same container may be run at a time.  
- - A singleton service is daemonized. A runtime MUST attempt to restart the singleton replica if it exits regardless of error code.
- - A singleton service has a network endpoint with an automatically assigned virtual IP address (VIP) and DNS name addressable within the network scope to which the component belongs.
+ - A Singleton Server is daemonized. A runtime MUST attempt to restart the singleton replica if it exits regardless of error code.
+ - A Singleton Server has a network endpoint with an automatically assigned virtual IP address (VIP) and DNS name addressable within the network scope to which the component belongs.
 
 ##### Worker
 Workload type name: `core.hydra.io/v1alpha1.Worker`
@@ -295,7 +295,7 @@ See the Units section above for valid values.
 #### Volume
 
 Volume describes name, a location to mount the volume, along with access mode (such as read/write or read-only) and sharing policy for the mount. It also describes the underneath disk attributes needed by the volume.
-The format of the path is specific to the operating system of the consuming service, though implementations SHOULD provide support for UNIX-like path representations.
+The format of the path is specific to the operating system of the consuming component, though implementations SHOULD provide support for UNIX-like path representations.
 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
@@ -472,20 +472,20 @@ to configure what kind of content the bot will tweet and the intervals at which
 it will do so.
 
 Because this component is stateless and horizontally scalable, it is described
-as a `ReplicableService`. The username, password, and address of the backend
+as a `Server`. The username, password, and address of the backend
 component are configurable.
 
 ```yaml
 apiVersion: core.hydra.io/v1alpha1
 kind: ComponentSchematic
 metadata:
-  name: replciatedservice
+  name: frontend
   annotations:
     version: v1.0.0
     description: >
       Sample component schematic that describes the administrative interface for our Twitter bot.
 spec:
-  workloadType: ReplicableService
+  workloadType: Server
   osType: linux
   parameters:
   - name: username
@@ -536,9 +536,9 @@ end-user-defined content at end-user-defined intervals (defined through the
 administrative interface). This component also persists its end-user-defined
 configuration to disk as a JSON file.
 
-This component's design prevents it from scaling horizontally, so we should only
-have at most _one_ instance of it running. As such, this component is described
-as a `Singleton`. Connection details for the Twitter API are
+This component's design prevents it from scaling horizontally so we should only
+have at most _one_ instance of it running. It also has an endpoint for an administrative interface. As such, this component is best described
+as a `SingletonServer`. Connection details for the Twitter API are
 configurable. The component schematic also describes the file system location
 where the component persists end-user-defined configuration.
 
@@ -546,13 +546,13 @@ where the component persists end-user-defined configuration.
 apiVersion: core.hydra.io/v1alpha1
 kind: ComponentSchematic
 metadata:
-  name: singletonservice
+  name: admin-backend
   annotations:
     version: v1.0.0
     description: >
       Sample component schematic that describes the backend for our Twitter bot.
 spec:
-  workloadType: core.hydra.io/v1.SingletonService
+  workloadType: core.hydra.io/v1.SingletonServer
   osType: linux
   parameters:
   - name: twitter-consumer-key

--- a/5.traits.md
+++ b/5.traits.md
@@ -43,7 +43,7 @@ The implementation details of a trait is beyond the scope of this document. Howe
 
 ## Trait characteristics
 
-An individual trait MAY be tied to specific workload types (or MAY apply to all workload types). A trait MAY declare which workload types it applies to. For example, an autoscaler trait could apply to a workload type _Service_, but not to type _Singleton Service_. The autoscaler trait itself MUST define that restriction if present.
+An individual trait MAY be tied to specific workload types (or MAY apply to all workload types). A trait MAY declare which workload types it applies to. For example, an autoscaler trait could apply to a workload type _Server_, but not to type _SingletonServer_. The autoscaler trait itself MUST define that restriction if present.
 
 The specification does not set requirements about how simple or complicated a trait may be. Some might expose an expansive set of configurable options while others may expose no configurable options. And it is not required that a trait be as exhaustive as its underlying technology. For example, an implementation of an autoscaling technology may provide numerous ways of determining when a component should scale. But the trait may only surface a few of those. Likewise, multiple autoscaling traits may be defined (each uniquely named), where each trait exposes a different subset of configurable options. Or one large trait may expose all of the possible autoscaling configurations.
 
@@ -91,7 +91,7 @@ This trait definition allows operators to manually scale the number of replicas 
 
 #### Applicable workload types 
 
- - `core.hydra.io/v1alpha1.Service`
+ - `core.hydra.io/v1alpha1.Server`
  - `core.hydra.io/v1alpha1.Worker`
  - `core.hydra.io/v1alpha1.Task`
 
@@ -113,7 +113,7 @@ metadata:
     description: "Allow operators to manually scale a workloads that allow multiple replicas."
 spec:
   appliesTo:
-    - core.hydra.io/v1alpha1.Service
+    - core.hydra.io/v1alpha1.Server
     - core.hydra.io/v1alpha1.Worker
     - core.hydra.io/v1alpha1.Task
   properties:
@@ -130,7 +130,7 @@ spec:
 
 #### Usage examples
 
-The following snippet from an application configuration shows how the manual scaler trait is applied and configured for a component. In this example, it is assumed component `frontend` has a workload type of `core.hydra.io/v1alpha1.Service`.
+The following snippet from an application configuration shows how the manual scaler trait is applied and configured for a component. In this example, it is assumed component `frontend` has a workload type of `core.hydra.io/v1alpha1.Server`.
 
 ```yaml
 apiVersion: core.hydra.io/v1alpha1

--- a/6.application_configuration.md
+++ b/6.application_configuration.md
@@ -193,7 +193,7 @@ This section uses a fictional tool called `hyctl` to illustrate a workflow patte
 
 ### Deploying two components with parameter overrides
 The following example shows two separate components:
- - a front-end web app in a container, run as a core replicated workload type
+ - a front-end web app in a container, run as a core Server workload type
  - a back-end Cassandra database, represented by an extended workload type.
 
 ```yaml
@@ -205,7 +205,7 @@ metadata:
     version: v1.0.0
     description: "A simple webserver"
 spec:
-  workloadType: core.hydra.io/v1.Replicated
+  workloadType: core.hydra.io/v1.Server
   parameters:
     - name: message
       description: The message to display in the web app.
@@ -289,9 +289,9 @@ $ hyctl trait-list
 ╔════════════╤═════════╤═════════════════════════════════════════════╗
 ║ NAME       │ VERSION │ PRIMITIVES                                  ║
 ╟────────────┼─────────┼─────────────────────────────────────────────╢
-║ autoscaler │ 0.1.0   │ replicatedService, quorumService            ║
+║ autoscaler │ 0.1.0   │ Server, Worker                              ║
 ╟────────────┼─────────┼─────────────────────────────────────────────╢
-║ ingress    │ 0.1.0   │ singleton, replicatedService, quorumService ║
+║ ingress    │ 0.1.0   │ SingletonServer, Server                     ║
 ╚════════════╧═════════╧═════════════════════════════════════════════╝
 ```
 

--- a/7.workload_types.md
+++ b/7.workload_types.md
@@ -37,9 +37,9 @@ This section describes the different naming references for this kind.
 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
-| `kind` | `string` | Y | | The proper reference name of the workload type (`Singleton`) |
-| `singular` | `string` | N | | The singular human-readable name of this type (`singleton`) |
-| `plural` | `string` | N | | The plural human-readable name of this type (`singletons`) |
+| `kind` | `string` | Y | | The proper reference name of the workload type (e.g., `Server`) |
+| `singular` | `string` | N | | The singular human-readable name of this type (e.g., `server`) |
+| `plural` | `string` | N | | The plural human-readable name of this type (e.g., `servers`) |
 
 `kind` must begin with a capital letter, and contain only characters 0030-0039, 0041-005a, and 0061-007a from the Unicode basic Latin characters.
 

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -54,7 +54,7 @@
             "workloadType":{
                 "type": "string",
                 "description": "A succinct, semantically meaningful descriptor of the component's runtime profile.",
-                "enum": ["Service", "SingletonService", "Worker", "Singleton Worker", "Task", "Singleton Task"]
+                "enum": ["Server", "SingletonServer", "Worker", "SingletonWorker", "Task", "SingletonTask"]
             },
             "osType":{
                 "type": "string",


### PR DESCRIPTION
This is primarily to avoid confusion with the "Service" object in Kubernetes. The semantics of the workload type remain unchanged. 

This PR replaces #104. See #104 for context on the naming decision.

Closes #86 
Closes #104 
