### PR TITLE
configuration: define scope accessibility and add `applicationScopes`

### DIFF
--- a/6.application_configuration.md
+++ b/6.application_configuration.md
@@ -369,8 +369,6 @@ spec:
       value: "Well hello there"
     - name: domainName
       value: "www.example.com"
-    - name: networkName
-      value: "my-vpc"
   components:
     - componentName: frontend
       instanceName: web-front-end


### PR DESCRIPTION
- In the meeting, we have discussed agreed to not add new concept but reuse existing AppConfig. The idea is that AppConfig will be accessible by components from any other application configuration. This would solve the reference problem
- The `applicationScopes` section is missing under `component`. This PR fix it.


closes https://github.com/microsoft/hydra-spec/issues/144 https://github.com/microsoft/hydra-spec/issues/130