### PR TITLE
configuration: fix mistaken variable

### DIFF
--- a/6.application_configuration.md
+++ b/6.application_configuration.md
@@ -365,7 +365,7 @@ spec:
       instanceName: web-front-end
       parameterValues:
         - name: message
-          value: "[fromVariable(networkName)]"
+          value: "[fromVariable(message)]"
       traits:
         - name: Ingress
           properties:


### PR DESCRIPTION
Should use `message` instead