### PR TITLE
Make README more approachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,53 @@
 # Hydra Specifications
 
+From the creators of 
+[Helm](https://helm.sh),
+[OpenKruise](https://openkruise.io/en-us/),
+and [Service Fabric](https://github.com/Microsoft/service-fabric),
+Hydra is a specification for building cloud native applications.
+
+Focused on the separation of development concerns from operational considerations,
+Hydra provides a set of tools for building high-grade containerized applications
+on systems like Kubernetes.
+
+*This repository is unstable, and open to contributions.*
+The specification is under development, and breaking changes are made regularly.
+Interested in contributing? Take a look at the issue queue! We're looking for more
+great ideas on how to model cloud native applications.
+
+## The Main Idea
+
+When it comes to the practice of software development and deployment, we think it is
+important to distinguish between the parts of the software that developers are
+responsible for, and the parts that operations is responsible for. Too often,
+these roles get muddled, resulting in communications mishaps, bugs, or even
+service outages.
+
+Hydra attempts to solve this problem by modeling the application according to the
+roles responsible for building and running apps and infrastructure.
+
+* _Developers_ are responsible for describing what a microservice or component does,
+  and _how_ it can be configured. They are the domain experts on the code.
+* _Application Operators_ are responsible for configuring the runtime aspects of
+  one or more of these microservices. They are the domain experts on the
+  platform.
+* _Infrastructure Operators_ are responsible for setting up and maintaining the
+  infrastructure within which applications run. They are the domain
+  experts on the low-level details.
+
+Hydra describes a model where developers are responsible for defining _components_,
+application operators are responsible for creating instances of those components and
+assigning them _application configurations_. And infrastructure operators are
+responsible for declaring, installing, and maintaining the underlying services that
+are available on the platform.
+
+For example, a _developer_ creates web application. The _application operator_ creates
+an instance of that application, and configures it to autoscale with load. The
+_infrastructure operator_ decides which underlying autoscaling technology is
+used to do the scaling.
+
+## About This Repository
+
 This repository holds the specifications for Hydra-compliant runtimes.
 
 Hydra is the code name for a broad initiative to define open
@@ -8,8 +56,6 @@ open source reference implementation thereof.
 
 The Hydra Specifications project is the definitive source for the
 open specifications.
-
-*This repository is unstable.* The specification is under development, and breaking changes are made regularly.
 
 ## Table of Contents
 


### PR DESCRIPTION
This is an attempt at making the first few paragraphs of the README more approachable in three ways:

1. It gives some ethos about who created the project
2. It gives a clear explanation (at a very high level) about the goals of the project
3. It invites people to participate right away