### PR TITLE
Fix typo and link in 'Representing Hydra Objects as Schematics' section

### DIFF
--- a/2.overview_and_terminology.md
+++ b/2.overview_and_terminology.md
@@ -86,7 +86,7 @@ An application configuration has the following parts:
 
 ## Representing Hydra Objects as Schematics
 
-The Hydra specification represents Hydra schematics (components, trait definitions, application configurations, etc.) as _schematics_. A schematic is a structured document that provides a declaration of an object or an object's desired state. Throughout this specification, schematics are represented in [YAML]() formatting. However, nothing in this specification forecloses the possibility of representing schematics as JSON documents or other similarly structured textual or binary representations.
+The Hydra specification represents Hydra objects (components, trait definitions, application configurations, etc.) as _schematics_. A schematic is a structured document that provides a declaration of an object or an object's desired state. Throughout this specification, schematics are represented in [YAML](https://yaml.org/). However, nothing in this specification forecloses the possibility of representing schematics as JSON documents or other similarly structured textual or binary representations.
 
 ### The Structure of a Schematic
 


### PR DESCRIPTION
* Changed `represents Hydra schematics (...) as schematics` to `represents Hydra objects (...) as schematics`
* Added link for `YAML` and removed extraneous `formatting`