### PR TITLE
fix typo in application scope example

### DIFF
--- a/6.application_configuration.md
+++ b/6.application_configuration.md
@@ -383,12 +383,12 @@ spec:
             - name: path
               value: "/"
       applicationScopes:
-        - myNetworkScope
+        - my-vpc-network
 
     - componentName: backend
       instanceName: database    
       applicationScopes:
-        - myNetworkScope
+        - my-vpc-network
 ```
 
 This example now shows a complete installation of the application configuration composed of two components, an ingress trait, and a network scope with parameters exposed to an application operator to customize the domain name, the network to deploy it to, and a custom message for the web front end to display.


### PR DESCRIPTION
The `myNetworkScope` represent the name of scope , while `my-vpc-network` represent the name of the instance of this kind scope.

I can't understand how component can bind with a scope name. We can only bind to the instance using `my-vpc-network`.

So this is a typo, right?

If I have anything misunderstood, please give some help.  @hongchaodeng  