### PR TITLE
Correct link text for Trait spec.properties

### DIFF
--- a/5.traits.md
+++ b/5.traits.md
@@ -73,7 +73,7 @@ The specification defines two major things: The list of workload types to which 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
 | `appliesTo` | `[]string` | Y | `["*"]` | The list of workload types that this trait applies to. `"*"` means _any workload type_. A trait must apply to at least one workload type. This attribute must contain at least one value. An empty array is invalid for this attribute. |
-| `properties` | [`JSON Schema`](#properties) | Y | | A [JSON schema](https://json-schema.org/) expressed as inline YAML for the trait's configuration options. |
+| `properties` | [`Properties`](#properties) | Y | | The trait's configuration options. The value is a [JSON schema](https://json-schema.org/) expressed as inline YAML. |
 
 ### Properties
 


### PR DESCRIPTION
* `JSON Schema` -> `Properties`
* Reword the attribute's description text 