### PR TITLE
trait: `properties` should use json string instead of inline yaml

### DIFF
--- a/5.traits.md
+++ b/5.traits.md
@@ -73,13 +73,13 @@ The specification defines two major things: The list of workload types to which 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
 | `appliesTo` | `[]string` | Y | `["*"]` | The list of workload types that this trait applies to. `"*"` means _any workload type_. A trait must apply to at least one workload type. This attribute must contain at least one value. An empty array is invalid for this attribute. |
-| `properties` | [`Properties`](#properties) | Y | | The trait's configuration options. The value is a [JSON schema](https://json-schema.org/) expressed as inline YAML. |
+| `properties` | [`Properties`](#properties) | Y | | The trait's configuration options. The value is a [JSON schema](https://json-schema.org/) expressed as json string |
 
 ### Properties
 
 A properties object is an object whose structure is determined by the trait property schema. It may be a simple value, or it may be a complex object.
 
-The value of the properties field in a trait definition is a [JSON schema](https://json-schema.org/) expressed as inline YAML. When a trait is applied to a component instance, the properties are validated against the schema defined in the trait's `properties` attribute.
+The value of the properties field in a trait definition is a [JSON schema](https://json-schema.org/) expressed as json string. When a trait is applied to a component instance, the properties are validated against the schema defined in the trait's `properties` attribute.
 
 For example, if a trait defines a schema for properties that requires an array of integers with at least one member, the properties object is expected to be an array of integers with at least one member. During validation of the properties object, the trait's property schema will be applied.
 
@@ -118,13 +118,19 @@ spec:
     - core.hydra.io/v1alpha1.Task
   properties:
     type: object
-    properties:
-      replicaCount:
-        description: the target number of replicas to scale a component to.
-        type: integer
-        minimum: 0
-      required:
-        - replicaCount
+    properties: |
+      {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": ["replicaCount],
+        "properties": {
+          "replicaCount": {
+            "type": "integer",
+            "description": "the target number of replicas to scale a component to.",
+            "minimum": 0
+          }
+        }
+      }
     
 ```
 


### PR DESCRIPTION
This is the outcome from offline discussion I have with @technosophos that "json schema expressed in inline yaml" idea has some drawbacks:

- json schema has some uses of '#', '$'. These aren't supported in yaml format.
- We barely found any tutorials online. Most of JSON schema is expressed in json string only.

As a result, we want to change it to json string instead.