### PR TITLE
add stage for trait

### DIFF
--- a/5.traits.md
+++ b/5.traits.md
@@ -73,6 +73,7 @@ The specification defines two major things: The list of workload types to which 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
 | `appliesTo` | `[]string` | Y | `["*"]` | The list of workload types that this trait applies to. `"*"` means _any workload type_. A trait must apply to at least one workload type. This attribute must contain at least one value. An empty array is invalid for this attribute. |
+| `stage` | `[]string` | N | `["postCreate", "postModify"]` | The list of stages that this trait should execute before or after workload execute. All stages are `"preCreate"`, `"postCreate"`, `"preModify"`, `"postModify"`, `"preDelete"`, `"postDelete"` which will define when will a trait execute around workload. A trait without stage defined will be executed after Workload create or modify. Traits with same stage will be executed by list order in spec. |
 | `properties` | [`Properties`](#properties) | Y | | The trait's configuration options. The value is a [JSON schema](https://json-schema.org/) expressed as json string |
 
 ### Properties
@@ -116,6 +117,9 @@ spec:
     - core.oam.dev/v1alpha1.Server
     - core.oam.dev/v1alpha1.Worker
     - core.oam.dev/v1alpha1.Task
+  stage:
+    - preCreate
+    - preModify
   properties: |
     {
       "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
fixes #235 


When we add some traits, maybe these traits are external resources, some external resource should be provisioned before workload create, some external resource should be bind to workload so they should execute after workload created.

In this case, we add `stage` to define order