### PR TITLE
scope: fix Network to allow multiple subnet IDs

### DIFF
--- a/4.application_scopes.md
+++ b/4.application_scopes.md
@@ -118,8 +118,11 @@ spec:
       description: The id of the network, e.g. vpc-id, VNet name.
       type: string
       required: Y
-    - name: subnet-id
-      description: The id of the subnet within the network.
+    - name: subnet-ids
+      description: >
+        A comma separated list of IDs of the subnets within the network. For example, "vsw-123" or ""vsw-123,vsw-456".
+        There could be more than one subnet because there is a limit in the number of IPs in a subnet.
+        If IPs are taken up, operators need to add another subnet into this network.
       type: string
       required: Y
     - name: internet-gateway-type


### PR DESCRIPTION
This is a recent finding when we are applying OAM in practice:

There could be more than one subnet because there is a limit in the number of IPs in a subnet.
If IPs are taken up, operators need to add another subnet into this network.