### PR TITLE
split appconfig example into two yamls

### DIFF
--- a/6.application_configuration.md
+++ b/6.application_configuration.md
@@ -337,8 +337,7 @@ Up to this point, the frontend component is deployed into the default "root" net
 
 The backend component is an extended workload type and is therefore not automatically deployed into the default "root' application scopes.
 
-In this example, a network scope is defined and attached to an SDN. Both components are then added to the same network scope for direct network connectivity and a shared set of network policies that can be defined by the infrastructure operator on the SDN itself. The SDN name is parameterized in the application configuration to allow an application operator to deploy this configuration into any SDN.
-
+In this example, a [network scope](./4.application_scopes.md#network-scope) is defined and attached to an SDN. Application Scope instance is also created by ApplicationConfiguration yaml like below:
 
 ```yaml
 apiVersion: core.oam.dev/v1alpha1
@@ -355,9 +354,14 @@ spec:
       properties:
         - name: network-id
           value: "[fromVariable(networkName)]"
-        - name: subnet-id
-          value: "my-subnet"
----
+        - name: subnet-ids
+          value: "my-subnet1, my-subnet2"
+```
+
+Both components are then added to the same network scope for direct network connectivity and a shared set of network policies that can be defined by the infrastructure operator on the SDN itself. The SDN name is parameterized in the application configuration to allow an application operator to deploy this configuration into any SDN.
+
+
+```yaml
 apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationConfiguration
 metadata:


### PR DESCRIPTION
Users maybe confused by when they are combined into one yaml especially app scope is a different kind of AppConfig 