### PR TITLE
add description and required for workloadsetting

### DIFF
--- a/3.component_model.md
+++ b/3.component_model.md
@@ -225,6 +225,8 @@ This section describes additional configuration for a workload (settings that ar
 | `name` | `string` | Y | | The name of this workload setting |
 | `type` | `string` | N | `string` | The data type passed into the value. This is used as a hint to the underlying implementation |
 | `value` | any | N || The value for this workload setting, if `fromParam` is not present |
+| `required` | bool | N || Whether a value _must_ be provided |
+| `description` | string | N || Describe what the setting is used for |
 | `fromParam` | string | N || The name of the parameter from whence to fetch the setting value. Overrides `value` |
 
 The `workloadSettings` section of a component schematic is an extensible location for specifying workload-specific configuration. The core workload types do not use this section, as it is reserved for extended workloads. Its primary purpose is to hold definitions for _non-containerized extended workload types_, though it may be used for containerized extended workload types where applicable.


### PR DESCRIPTION
Now WorkloadSetting is used to describe what kind of parameters can be used for extended workload in ComponentSchematic.

It's necessary to give description and whether it's required in WorkloadSettings.