### PR TITLE
make value in parameter required

### DIFF
--- a/6.application_configuration.md
+++ b/6.application_configuration.md
@@ -143,7 +143,7 @@ Values supplied to parameters that are used to override the parameters exposed b
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
 | `name` | `string` | Y | | The name of the component parameter to provide a value for. |
-| `value` | `string` | N || The value of this parameter. |
+| `value` | `string` | Y || The value of this parameter. |
 
 A `name` is any Unicode letter or numeric character, `_`, `-`, and `.`. A `value` is any sequence of printable Unicode characters.
 


### PR DESCRIPTION
There's no reason to declare a parameter with no value.