### PR TITLE
declare that OAM runtime could have more extended application scopes

### DIFF
--- a/4.application_scopes.md
+++ b/4.application_scopes.md
@@ -41,7 +41,7 @@ Core application scope types define grouping constructs for basic runtime behavi
 
 ### Extended application scope types
 
-Extended application scopes are optional per runtime, meaning that each runtime may choose which extended scopes are supported. In this version of the spec, allowing user-defined extended application scope types is not supported.
+Extended application scopes are optional per runtime, meaning that each runtime may choose which extended scopes are supported. It is expected that runtimes will implement extended scopes as they need. In this version of the spec, allowing user-defined extended application scope types is not supported.
 
 ## Defining an application scope
 This section is normative because application scopes are an inspectable (and possibly shareable) part of the system. All scopes MUST be representable in the following format.
@@ -187,9 +187,12 @@ spec:
 ```
 
 ## Extended application scope type definitions
+
 The following extended scope types are available:
 - resource quota scope
 - identity scope
+
+Besides the above scopes, the runtime could have more extended application scopes as needed.
 
 ### Resource Quota scope
 The resource quota scope sets resource quotas on a group of components. Resources include CPU, memory, storage, etc. Setting resource quotas for a scope applies across all components within the scope; in other words, the total resource consumption for all components within a scope cannot exceed a certain value.


### PR DESCRIPTION
fixes #254 

We should declare that OAM runtime could define more application scopes then what defined in the spec now.