### PR TITLE
Remove "in MB" from memory description

### DIFF
--- a/3.component_model.md
+++ b/3.component_model.md
@@ -286,7 +286,7 @@ See the Units section above for valid values.
 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
-| `required` | `string` | Y | | The minimum amount of memory in MB required  for running this container. The value should be a positive integer, greater than zero. |
+| `required` | `string` | Y | | The minimum amount of memory required  for running this container. The value should be a positive integer or positive integer using one of these suffixes: P, T, G, M, K. |
 
 See the Units section above for valid values.
 

--- a/3.component_model.md
+++ b/3.component_model.md
@@ -286,7 +286,7 @@ See the Units section above for valid values.
 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
-| `required` | `string` | Y | | The minimum amount of memory required  for running this container. The value should be a positive integer or positive integer using one of these suffixes: P, T, G, M, K. |
+| `required` | `string` | Y | | The minimum amount of memory required for running this container. The value should be a positive integer with/without unit suffix: P, T, G, M, K. If no unit is given, it defaults to 'bytes'. |
 
 See the Units section above for valid values.
 


### PR DESCRIPTION
Fixed #271 

The default unit "MB" in memory description is conflict with unit description.