### PR TITLE
fix definition of application scope to be properties

### DIFF
--- a/4.application_scopes.md
+++ b/4.application_scopes.md
@@ -3,6 +3,7 @@
 Application scopes are used to group components together into logical applications by providing different forms of application boundaries with common group behaviors.
 
 Application scopes have the following general characteristics:
+
  - Application scopes SHOULD be used when defining behavior or metadata that is common to a group of component instances.
  - A component MAY be deployed into multiple application scopes of different types simultaneously. 
  - Application scope types MAY determine whether or not components can be deployed into multiple instances of the same application scope type simultaneously. 
@@ -19,11 +20,14 @@ Components A, B, and C are deployed to the same health scope. The health scope w
 Component A is isolated in its own network scope from components B, C, and D. This allows the infrastructure operator to supply different SDN settings for different groups of components, such as more restricted inbound/outbound rules on back-end components.
 
 ## Application scope types
+
 There are two kinds of application scope types:
+
  - Core application scope types
  - Extended application scope types
 
 ### Core application scope types
+
 Core application scope types define grouping constructs for basic runtime behavior. They have the following characteristics:
 
  - Core application scope types MUST be in the `core.oam.dev` namespace.
@@ -44,6 +48,7 @@ Core application scope types define grouping constructs for basic runtime behavi
 Extended application scopes are optional per runtime, meaning that each runtime may choose which extended scopes are supported. In this version of the spec, allowing user-defined extended application scope types is not supported.
 
 ## Defining an application scope
+
 This section is normative because application scopes are an inspectable (and possibly shareable) part of the system. All scopes MUST be representable in the following format.
 
 Application scopes are defined with schematics like components and traits.
@@ -67,33 +72,32 @@ The spec defines the constituent parts of a scope.
 |-----------|------|----------|---------------|-------------|
 | `type` | `string` | Y | | Determines type of the application scope. The core types are defined [above](#core-application-scope-types) |
 | `allowComponentOverlap` | `bool` | Y | | Determines whether a component is allowed to be in multiple instances of this scope type simultaneously. When false, the runtime implementation MUST produce an error and stop deployment if an attempt is made to place a component into more than one instance of this scope type simultaneously. |
-| `parameters` | [`[]Parameter`](#parameter) | N | | The scope's configuration options. |
+| `properties` | [`Properties`](#properties) | N | | The scope's configuration options. The value is a [JSON schema](https://json-schema.org/) expressed as json string |
 
 The `type` field defines the type name for this type. Examples may be found in the [Core Application Scope Types](#core-application-scope-types) above. Extended scope types MUST NOT be in the `core.oam.dev` namespace.  However, they must follow the [group, version, kind notation](2.overview_and_terminology.md). For example: `scopes.example.com/v1.ExtendedNetworkScope`
 
-#### Parameter
+#### Properties
 
-The parameters that a scope exposes to operators.
+A properties object is an object whose structure is determined by the scope property schema. It may be a simple value, or it may be a complex object.
 
-| Attribute | Type | Required | Default Value | Description |
-|-----------|------|----------|---------------|-------------|
-| `name` | `string` | Y | | The parameter's name. Must be unique per scope. |
-| `description` | `string` | N | | A description of the parameter. |
-| `type` | `string` | Y | | The parameter's type (One of `string`, `boolean`, `number`). |
-| `required` | `boolean` | N |`false` | Whether a value _must_ be provided for the parameter. |
-| `default` | type indicated by `type` field | N | | The parameter's default value. |
+The value of the properties field in a scope definition is a [JSON schema](https://json-schema.org/) expressed as json string. When a scope is used in Application Configuration, the properties are validated against the schema defined in the scope's `properties` attribute.
 
-The `name` field allows Unicode letters, numbers and `_` and `-`. The `description` field allows those characters plus whitespace and punctuation characters.
+For example, if a scope defines a schema for properties that requires an array of integers with at least one member, the properties object is expected to be an array of integers with at least one member. During validation of the properties object, the scope's property schema will be applied.
+
 
 ## Deployment
+
 Application scope instances are defined and deployed in an application configuration. See [Application Configuration](6.application_configuration.md) for more information on deploying scopes.
 
 ## Core scope type definitions
+
 The following core scope types are available:
+
 - network scope
 - health scope
 
 ### Network scope
+
 The network scope groups components together and links them to a network or SDN. The network itself must be defined and operated by the infrastructure.
 
 The network scope may also be queried by traffic management traits to determine discoverability boundaries for a service mesh or API boundaries for API gateways.
@@ -113,7 +117,7 @@ metadata:
 spec:
   type: core.oam.dev/v1.NetworkScope
   allowComponentOverlap: false
-  parameters:
+  properties:
     - name: network-id
       description: The id of the network, e.g. vpc-id, VNet name.
       type: string
@@ -132,9 +136,11 @@ spec:
 ```
 
 ### Health scope
+
 The health scope aggregates health states for components. Parameters of the health scope can be set to determine the percentage of components that must be unhealthy to consider the entire scope unhealthy.
 
 The health scope on its own does not take any action based on health status. It is only a group health aggregator that can be queried and used by other processes and parts of an application, such as:
+
  - Application upgrade traits can monitor the aggregate health of a health scope and decide when to initiate an automatic rollback.
  - Monitoring applications can monitor the aggregate health of a health scope to issue alerts.
 
@@ -151,7 +157,7 @@ metadata:
 spec:
   type: core.oam.dev/v1alpha1.HealthScope
   allowComponentOverlap: true
-  parameters:
+  properties:
     - name: probe-method
       description: The method to probe the components, e.g. 'httpGet'.
       type: string
@@ -187,15 +193,20 @@ spec:
 ```
 
 ## Extended application scope type definitions
+
 The following extended scope types are available:
+
 - resource quota scope
 - identity scope
 
 ### Resource Quota scope
+
 The resource quota scope sets resource quotas on a group of components. Resources include CPU, memory, storage, etc. Setting resource quotas for a scope applies across all components within the scope; in other words, the total resource consumption for all components within a scope cannot exceed a certain value.
 
 #### Example
-This is an example of a resource quota scope definition. 
+
+This is an example of a resource quota scope definition.
+
 ```yaml
 apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationScope
@@ -207,7 +218,7 @@ metadata:
 spec:
   type: resources.oam.dev/v1.ResourceQuotaScope
   allowComponentOverlap: false
-  parameters:
+  properties:
     - name: CPU
       description: maximum CPU to be consumed by this scope
       type: double
@@ -223,7 +234,9 @@ spec:
 The identity scope provides identities in components when authenticating to any service. The identities and its credentials are supplied and managed by an external identity provider.
 
 #### Example
-This is an example of a identity scope definition. 
+
+This is an example of a identity scope definition.
+
 ```yaml
 apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationScope
@@ -235,7 +248,7 @@ metadata:
 spec:
   type: identity.oam.dev/v1.IdentityScope
   allowComponentOverlap: true
-  parameters:
+  properties:
     - name: IdentityProvider
       description: the provider of identity for the scope
       type: string
@@ -247,4 +260,3 @@ spec:
 | Previous Part        | Next Part           | 
 | ------------- |-------------|
 | [3. The Component Model](3.component_model.md)     | [5. Traits](5.traits.md) |
-


### PR DESCRIPTION
When our cloud team try to implement a kind of scope, we find the scope is lack of extension as it can only support `string`, `number` or `bool`.

But I find @technosophos  and @vturecek  have discussed this issue (https://github.com/oam-dev/spec/pull/7) and made a decision to use properties. 

So I think this is just the missing part of that PR.