### PR TITLE
add a tip to tell one of components or scopes is required

### DIFF
--- a/6.application_configuration.md
+++ b/6.application_configuration.md
@@ -74,6 +74,7 @@ The specification defines three major things: Parameters that can be overridden 
 | `scopes` | [`[]Scope`](#scope) | N | | Application scope definitions. If defined, scopes are accessible by components from any other application configurations. |
 | `components` | [`[]Component`](#component) | N | | Component instance definitions. |
 
+One of `scopes` or `components` is required while the other one is optional.
 
 ### Variable
 The Variables section defines variables that may be used elsewhere in the application configuration. The `variable` section provides a way for an application operator to specify common values that can be substituted into multiple other locations in this configuration (using the `[fromVariable(VARNAME)]` syntax).


### PR DESCRIPTION
The field `spec` in AppConfig is required while the fields in `spec` are all optional, this makes confusion, so I add a tip to make it clear 