### PR TITLE
add community talks and blogs resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,7 @@ One of the easiest ways to contribute is to participate in discussions. There ar
 | Twitter      | [@oam_dev](https://twitter.com/oam_dev) |
 
 [how-it-works]: assets/how-it-works.png
+
+### Resources
+
+Come find community blogs and conference talks about OAM in [community/talks_and_blogs.md](./community/talks_and_blogs.md).

--- a/community/talks_and_blogs.md
+++ b/community/talks_and_blogs.md
@@ -1,0 +1,11 @@
+# OAM Community Resources
+
+Here are a list of blogs:
+
+- [The Open Application Model from Alibaba’s Perspective](https://www.infoq.com/articles/oam-alibaba/)
+
+
+Here are a list of talks recorded:
+
+- Mark Russinovich presents [Dapr, Rudr, OAM](https://www.youtube.com/watch?v=LAUDVk8PaCY)
+- Sudhanva presented at [CNCF SIG-App-Delivery meeting](https://youtu.be/AJ6MNcN-sH8?t=1407)


### PR DESCRIPTION
Many open source projects list community talks and blogs to influence initial users and show user cases.

It would be great if we start setting it up. Initially, we could just put it under the repo.