### PR TITLE
[br: 0.3.0-dev] fix expose field as string and clarify it should be unique

### DIFF
--- a/3.component_model.md
+++ b/3.component_model.md
@@ -64,7 +64,7 @@ The spec defines the constituent parts of a component.
 | `arch` | `string` | N |  | The CPU architecture required to host (all of) the component's containers (since containers share physical hardware with the underlying host). Possible values include:<ul><li>i386</li><li>amd64</li><li>arm</li><li>arm64</li></ul> Default can be none and let the runtime chose architecture. |
 | `containers` | [`[]Container`](#container) | N | | The OCI container(s) that implement the component. |
 | `workloadSettings` | [`Properties`](#properties) | N | | Declaration of non-container settings that should be passed to the workload runtime |
-| `expose` | [`[]Expose`](#expose) | N | | The name of place that the component will output |
+| `expose` | `string` | N | | The name of secret containing the information this component will output. The name MUST be unique in the same namespace |
 | `consume` | [`[]Consume`](#consume) | N | | Where and how that the component will consume |
 
 
@@ -471,13 +471,6 @@ Both `name` and `value` must abide by the HTTP/1.1 specification for valid [head
 
 Port must be an integer value greater than `0`.
 
-
-### Expose
-
-| Attribute | Type | Required | Default Value | Description |
-|-----------|------|----------|---------------|-------------|
-| `name` | `string` | Y | | The output's name, it could be implemented as a file or something else. The name must be unique per component. |
-| `global` | `boolean` | N | | Define whether the expose could be consumed globally. |
 
 ### Consume
 


### PR DESCRIPTION
1. we can't expose an array, as workload won't know which expose file to output, the workload can only output the whole thing to only one file from expose.
2. the component is applied before AppConfig, while AppConfig can arbitrary combine different components, we have no way to check when AppConfig is created, only check it when component is created, so it must be globally unique.