### PR TITLE
change trait name from CamelCase to snake_case

### DIFF
--- a/5.traits.md
+++ b/5.traits.md
@@ -4,11 +4,11 @@ A _trait_ is a discretionary runtime overlay that augments a component workload 
 
 The _traits system_ is defined in this specification as the way a runtime applies and manages operational behaviors to instances of components through traits.
 
-Runtime implementations of the specification MUST provide the traits system for attaching operational behaviors to instances of components. 
+Runtime implementations of the specification MUST provide the traits system for attaching operational behaviors to instances of components.
 
-## Traits system rules and characteristics 
+## Traits system rules and characteristics
 
-Traits are applied to component instances in the [application configuration](6.application_configuration.md). 
+Traits are applied to component instances in the [application configuration](6.application_configuration.md).
 
 Traits should be applied into the runtime at installation/upgrade time. Traits should not be checked "lazily", but should be checked when the trait-holding components are created.
 
@@ -53,7 +53,7 @@ Implementations of an OAM runtime SHOULD make all supported traits discoverable 
 
 This section is normative because traits are an inspectable (and possibly shareable) part of the system. All traits MUST be representable in the following format.
 
-Traits are defined with schematics like components. Unlike component schematics, however, each trait definition defines its own unique [properties]((#properties) object schema to define the configuration options for the trait.  
+Traits are defined with schematics like components. Unlike component schematics, however, each trait definition defines its own unique [properties]((#properties) object schema to define the configuration options for the trait.
 
 ### Top-Level Attributes
 
@@ -89,7 +89,7 @@ For example, if a trait defines a schema for properties that requires an array o
 
 This trait definition allows operators to manually scale the number of replicas for workload types that allow scaling operations.
 
-#### Applicable workload types 
+#### Applicable workload types
 
  - `core.oam.dev/v1alpha1.Server`
  - `core.oam.dev/v1alpha1.Worker`
@@ -107,7 +107,7 @@ This trait definition allows operators to manually scale the number of replicas 
 apiVersion: core.oam.dev/v1alpha1
 kind: Trait
 metadata:
-  name: ManualScaler
+  name: manual-scaler
   annotations:
     version: v1.0.0
     description: "Allow operators to manually scale a workloads that allow multiple replicas."
@@ -131,7 +131,7 @@ spec:
         }
       }
     }
-    
+
 ```
 
 #### Usage examples
@@ -153,7 +153,7 @@ spec:
       instanceName: web-front-end
       parameterValues:
       traits:
-        - name: ManualScaler
+        - name: manual-scaler.core.oam.dev/v1alpha1
           properties:
             replicaCount: 5
 ```
@@ -161,6 +161,6 @@ spec:
 This example illustrates using the manual scaler trait to manually scale a component by specifying the number of replicas the runtime should create. This trait has only one attribute in its properties: `replicaCount`. This takes an integer, and a value is required for this trait to be successfully applied. If, for example, an application configuration used this trait but did not provide the `replicaCount`, the system would reject the application configuration.
 
 
-| Previous Part        | Next Part           | 
+| Previous Part        | Next Part           |
 | ------------- |-------------|
 | [4. Application Scopes](4.application_scopes.md) | [6. Application Configuration](6.application_configuration.md) |

--- a/6.application_configuration.md
+++ b/6.application_configuration.md
@@ -176,10 +176,10 @@ spec:
         - name: ANOTHER_PARAMETER
           value: "[fromVariable(VAR_NAME)]"
       traits:
-        - name: Ingress
+        - name: ingress.core.oam.dev/v1alpha1
           properties:
             DATA: "[fromVariable(VAR_NAME)]"
-              
+
 ```
 
 The example above illustrates a complete application configuration scopes, component instances, their traits, and parameter overrides that allow users to specify values at deployment time from the command line.
@@ -247,7 +247,7 @@ Note that each component allows certain parameters to be overridden. For example
 
 Components can be designed for reuse by expose such parameters, as these parameters can be tweaked for different deployment scenarios.
 
-An application configuration combines any number of components and sets operational characteristics and configuration for a deployed _instance_ of each component. 
+An application configuration combines any number of components and sets operational characteristics and configuration for a deployed _instance_ of each component.
 
 ```yaml
 apiVersion: core.oam.dev/v1alpha1
@@ -267,7 +267,7 @@ spec:
       parameterValues:
         - name: message
           value: "[fromVariable(message)]"
-          
+
     - componentName: backend
       instanceName: database
 ```
@@ -319,7 +319,7 @@ spec:
         - name: message
           value: "[fromVariable(message)]"
       traits:
-        - name: Ingress
+        - name: ingress.core.oam.dev/v1alpha1
           properties:
             host: domainName
             path: "/"
@@ -378,7 +378,7 @@ spec:
         - name: message
           value: "[fromVariable(message)]"
       traits:
-        - name: Ingress
+        - name: ingress.core.oam.dev/v1alpha1
           properties:
             host: "[fromVaraible(domainName)]"
             path: "/"
@@ -393,6 +393,6 @@ spec:
 
 This example now shows a complete installation of the application configuration composed of two components, an ingress trait, and a network scope with parameters exposed to an application operator to customize the domain name, the network to deploy it to, and a custom message for the web front end to display.
 
-| Tables        | Next           | 
-| ------------- |-------------| 
+| Tables        | Next           |
+| ------------- |-------------|
 | [5. Traits](5.traits.md)       | [7. Workload Types](7.workload_types.md) |


### PR DESCRIPTION
ref: https://github.com/oam-dev/spec/issues/299

In Rudr the trait names are all in snake_case due to k8s naming restrictions.
To make the spec clear and consistent to users, we'd better fix all trait names to be snake_case.