### PR TITLE
[1.0.0-alpha2]Rewording and example fixes on Overview and Workload

### DIFF
--- a/2.overview_and_terminology.md
+++ b/2.overview_and_terminology.md
@@ -145,6 +145,19 @@ metadata:
     name: foo
 ```
 
+*Okay:* Each group (`one.dev` and `other.dev`) allows the kind `Component` with name `foo`.
+```yaml
+apiVersion: one.dev/v1alpha2
+kind: Component
+metadata:
+    name: foo
+---
+apiVersion: other.dev/v1alpha2
+kind: Component
+metadata:
+    name: foo
+```
+
 *NOT Okay:* Version is not a namespace qualifier.
 
 ```yaml
@@ -176,7 +189,7 @@ Annotations provide a mechanism for attaching arbitrary text within the metadata
 
 > Annotations are key/value pairs. Valid annotation keys have two segments: an optional prefix and name, separated by a slash (/). The name segment is required and must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between. The prefix is optional. If specified, the prefix must be a DNS subdomain: a series of DNS labels separated by dots (.), not longer than 253 characters in total, followed by a slash (/).
 
-The following annotation labels are _predefined_ and are _strongly recommended_.
+The following annotation labels are _predefined_ and NOT RECOMMENDED.
 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
@@ -268,7 +281,7 @@ apiVersion: local.dev/v7alpha2
 kind: Proxy
 ```
 
-In rare cases, it is necessary to link a group and a kind, but without specifying a version. This is done, for example, when declaring default workload. As a general rule, this behavior should be avoided whenever necessary, but when it is necessary, this specification follows the Kubernetes pattern of construct a DNS name out of the plural kind name and the group:
+In rare cases, it is necessary to link a group and a kind, but without specifying a version. This is done, for example, when declaring default workload. As a general rule, this behavior is NOT RECOMMENDED, but when necessary, this specification follows the Kubernetes pattern of construct a DNS name out of the plural kind name and the group:
 
 ```
 Proxies.local.dev # allowed but discouraged

--- a/2.overview_and_terminology.md
+++ b/2.overview_and_terminology.md
@@ -189,7 +189,7 @@ Annotations provide a mechanism for attaching arbitrary text within the metadata
 
 > Annotations are key/value pairs. Valid annotation keys have two segments: an optional prefix and name, separated by a slash (/). The name segment is required and must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between. The prefix is optional. If specified, the prefix must be a DNS subdomain: a series of DNS labels separated by dots (.), not longer than 253 characters in total, followed by a slash (/).
 
-The following annotation labels are _predefined_ and NOT RECOMMENDED.
+The following annotation labels are _predefined_ and RECOMMENDED.
 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|

--- a/3.workload.md
+++ b/3.workload.md
@@ -44,7 +44,7 @@ The workload schema definition itself __MUST__ contain information that can be u
 
 We recommend that the `name` here follows the format described in [the Representations of Group/Kind in section 2](2.overview_and_terminology.md#Representations).
 
-We also recommend that the `name` of the workloadDefinition to be the same as the `name` it refers to. Here is an example
+We also recommend that the `name` of the WorkloadDefinition to be the same as the `name` it refers to. Here is an example
 
 ```yaml
 apiVersion: core.oam.dev/v1alpha2
@@ -53,7 +53,7 @@ metadata:
   name: schema.example.oam.dev
 spec:
   definitionRef:
-    schemaName: schema.example.oam.dev
+    name: schema.example.oam.dev
 ```
 
 ## Categories of Workload
@@ -62,7 +62,7 @@ There are three categories of workloads:
 
 __Core workloads__ are the kind of workloads that every OAM runtime MUST implement according to spec definition.
 
-__Standard workloads__ are the kind of workloads that a OAM runtime can choose to implement. However, the implementation MUST strictly adhere to the schematics defined in the spec. 
+__Standard workloads__ are the kind of workloads that a OAM runtime MAY implement. However, the implementation MUST strictly adhere to the schematics defined in the spec. 
 
 __Extended workloads__ are the kind of workloads that a OAM runtime is free to define.
 


### PR DESCRIPTION
* Example for same name, same kind but different group.
* Fix one example in WorkloadDefinition
* Rewording to match RFC 2119
* Ad-hoc rewording