### PR TITLE
[1.0.0-alpha2] rectify parameter fieldPath to have leading dot

### DIFF
--- a/4.component.md
+++ b/4.component.md
@@ -49,7 +49,7 @@ The Parameters section defines all of the configurable parameters for this compo
 
 Parameter `name` fields must be Unicode letter and number characters. Application Configurations will specify parameters values using this name.
 
-Parameter `fieldPaths` specifies an array of fields within this Component's workload that will be overwritten by the value of this parameter. `fieldPaths` are specified as JSON field paths without a leading dot, for example `spec.containers[0].image`. The type of the parameter is inferred by the type of the fields those paths refer. Thus, all fields those paths refer to __MUST__ have the same type and __MUST NOT__ be object type. 
+Parameter `fieldPaths` specifies an array of fields within this Component's workload that will be overwritten by the value of this parameter. `fieldPaths` are specified as JSON field paths with a leading dot, for example `.spec.containers[0].image`. The type of the parameter is inferred by the type of the fields those paths refer to. Thus, all fields those paths refer to __MUST__ have the same type and __MUST NOT__ be object type. 
 
 ### Examples
 
@@ -99,11 +99,11 @@ spec:
   - name: imageName
     required: false
     fieldPaths: 
-    - "spec.containers[0].image"
+    - ".spec.containers[0].image"
   - name: cacheSecret
     required: true
     fieldPaths:
-    - "spec.containers[0].env[0].value"
+    - ".spec.containers[0].env[0].value"
 ```
 
 | Previous Part        | Next Part           | 

--- a/examples/workflow.md
+++ b/examples/workflow.md
@@ -43,7 +43,7 @@ spec:
     required: true
     type: string
     fieldPaths:
-    - "spec.containers[0].env[0].value"
+    - ".spec.containers[0].env[0].value"
 ```
 
 ```yaml
@@ -66,12 +66,12 @@ spec:
       description: Max stale requests.
       type: int
       fieldPaths:
-      - "spec.maxStalenessPrefix"
+      - ".spec.maxStalenessPrefix"
     - name: defaultConsistencyLevel
       description: The default consistency level
       type: string
       fieldPaths:
-      - "spec.defaultConsistencyLevel"
+      - ".spec.defaultConsistencyLevel"
 ```
 
 Note that each component allows certain parameters to be overridden. For example, the `message` parameter is exposed for configuration in the frontend component. Within the component config, the parameter is piped to an environment variable where the component code can read the value.


### PR DESCRIPTION
I have walked through the spec over the weekends and found this discrepancy with the [design doc](https://github.com/oam-dev/spec/blob/master/design/20200105-spec-v1alpha2-kubernetes-friendly.md)