### PR TITLE
Fix missing meeting info

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ One of the easiest ways to contribute is to participate in discussions. There ar
 | Mailing List | https://groups.google.com/forum/#!forum/oam-dev |
 | Community meeting info | [Bi-weekly (Starting Oct 22, 2019), Tuesdays 10:30AM PST](https://calendar.google.com/calendar?cid=dDk5YThyNGIwOWJyYTJxajNlbWI0a2FvdGtAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ)  |
 | APAC Friendly Community meeting | [Bi-weekly APAC (Starting Dec 24, 2019), Tuesdays 1:00PM GMT+8](https://calendar.google.com/event?action=TEMPLATE&tmeid=MzJnbHR2b3R1bHYxMG0wc2YybDJjZmhuc2pfMjAxOTEyMjRUMDUwMDAwWiBmZW5namluZ2NoYW9AbQ&tmsrc=fengjingchao%40gmail.com&scp=ALL) |
-| Community meeting link | https://zoom.us/j/271516061 |
+| Meeting link | https://zoom.us/j/271516061 |
+| Meeting notes| [Notes and agenda](https://docs.google.com/document/d/1nqdFEyULekyksFHtFvgvFAYE-0AMHKoS3RMnaKsarjs) |
+| Meeting recordings| [Recordings](https://drive.google.com/drive/folders/1yr5LSB8NkEYxzBL-R9D-z-UwVYx4luLe) |
 | IM Channel      | https://gitter.im/oam-dev/ |
 | Twitter      | [@oam_dev](https://twitter.com/oam_dev) |
 


### PR DESCRIPTION
Just as the title said.

Though I'd suggest we move meeting recordings to Youtube channel later.