### PR TITLE
Don't require a leading dot for JSON field paths

### DIFF
--- a/4.component.md
+++ b/4.component.md
@@ -49,7 +49,7 @@ The Parameters section defines all of the configurable parameters for this compo
 
 Parameter `name` fields must be Unicode letter and number characters. Application Configurations will specify parameters values using this name.
 
-Parameter `fieldPaths` specifies an array of fields within this Component's workload that will be overwritten by the value of this parameter. `fieldPaths` are specified as JSON field paths with a leading dot, for example `.spec.containers[0].image`. The type of the parameter is inferred by the type of the fields to which those paths refer. Thus, all fields to which those paths refer MUST have the same type and MUST NOT be object type.
+Parameter `fieldPaths` specifies an array of fields within this Component's workload that will be overwritten by the value of this parameter. `fieldPaths` are specified as JSON field paths without a leading dot, for example `spec.containers[0].image`. The type of the parameter is inferred by the type of the fields to which those paths refer. Thus, all fields to which those paths refer MUST have the same type and MUST NOT be object type.
 
 ### Examples
 


### PR DESCRIPTION
https://github.com/kubernetes/community/blob/ddc11a7/contributors/devel/sig-architecture/api-conventions.md#selecting-fields

This allows us to leverage existing libraries and patterns designed for Kubernetes field paths, per https://github.com/crossplane/crossplane-runtime/issues/136.