### PR TITLE
Do not require a leading dot for JSON field paths

### DIFF
--- a/4.component.md
+++ b/4.component.md
@@ -99,11 +99,11 @@ spec:
   - name: imageName
     required: false
     fieldPaths: 
-    - ".spec.containers[0].image"
+    - "spec.containers[0].image"
   - name: cacheSecret
     required: true
     fieldPaths:
-    - ".spec.containers[0].env[0].value"
+    - "spec.containers[0].env[0].value"
 ```
 
 | Previous Part        | Next Part           | 

--- a/4.component.md
+++ b/4.component.md
@@ -49,7 +49,7 @@ The Parameters section defines all of the configurable parameters for this compo
 
 Parameter `name` fields must be Unicode letter and number characters. Application Configurations will specify parameters values using this name.
 
-Parameter `fieldPaths` specifies an array of fields within this Component's workload that will be overwritten by the value of this parameter. `fieldPaths` are specified as JSON field paths with a leading dot, for example `.spec.containers[0].image`. The type of the parameter is inferred by the type of the fields to which those paths refer. Thus, all fields to which those paths refer MUST have the same type and MUST NOT be object type.
+Parameter `fieldPaths` specifies an array of fields within this Component's workload that will be overwritten by the value of this parameter. `fieldPaths` are specified as JSON field paths without a leading dot, for example `spec.containers[0].image`. The type of the parameter is inferred by the type of the fields to which those paths refer. Thus, all fields to which those paths refer MUST have the same type and MUST NOT be object type.
 
 ### Examples
 

--- a/design/20200105-spec-v1alpha2-kubernetes-friendly.md
+++ b/design/20200105-spec-v1alpha2-kubernetes-friendly.md
@@ -120,7 +120,7 @@ This document proposes:
 1. An ApplicationConfiguration _references_ distinct Component resources,
    grouping them into one logical application and providing inputs to their
    parameters.
-1. Each Component embed an OAM “workload” under the `.spec.workload` key.
+1. Each Component embed an OAM “workload” under the `spec.workload` key.
    Available workloads are defined by WorkloadDefinitions. In Kubernetes
    runtimes any existing custom resource with a corresponding WorkloadDefinition
    can be used in a Component.
@@ -195,19 +195,19 @@ spec:
   - name: instanceName
     required: true
     fieldPaths:
-    - ".metadata.name"
+    - "metadata.name"
   - name: cacheSecret
     required: true
     fieldPaths:
-    - ".spec.containers[0].env[0].value"
+    - "spec.containers[0].env[0].value"
 ```
 
 Components would most frequently be defined by application developers. A
 Component has two responsibilities:
 
-1. Embed a valid OAM workload kind under its `.spec.workload` field.
-2. Publish a set of parameters under its `.spec.parameters` field. Parameters
-   may be set by an ApplicationConfig. Their values overlay onto fields in the
+1. Embed a valid OAM workload kind under its `spec.workload` field.
+2. Publish a set of parameters under its `spec.parameters` field. Parameters may
+   be set by an ApplicationConfig. Their values overlay onto fields in the
    embedded OAM workload.
 
 The embedded OAM workload is a template of a sorts - though it is important to
@@ -257,11 +257,11 @@ spec:
   - name: secret
     required: true
     fieldPaths:
-    - ".spec.writeConnectionSecretToRef.name"
+    - "spec.writeConnectionSecretToRef.name"
   - name: engineVersion
     required: false
     fieldPaths:
-    - ".spec.engineVersion"
+    - "spec.engineVersion"
 ```
 
 The above WorkloadDefinition and Component leverages the existing Crossplane

--- a/examples/workflow.md
+++ b/examples/workflow.md
@@ -43,7 +43,7 @@ spec:
     required: true
     type: string
     fieldPaths:
-    - ".spec.containers[0].env[0].value"
+    - "spec.containers[0].env[0].value"
 ```
 
 ```yaml
@@ -66,12 +66,12 @@ spec:
       description: Max stale requests.
       type: int
       fieldPaths:
-      - ".spec.maxStalenessPrefix"
+      - "spec.maxStalenessPrefix"
     - name: defaultConsistencyLevel
       description: The default consistency level
       type: string
       fieldPaths:
-      - ".spec.defaultConsistencyLevel"
+      - "spec.defaultConsistencyLevel"
 ```
 
 Note that each component allows certain parameters to be overridden. For example, the `message` parameter is exposed for configuration in the frontend component. Within the component config, the parameter is piped to an environment variable where the component code can read the value.


### PR DESCRIPTION
This cherry-picks 72eecb65d10aa98d94515946a342617f832311c7 from the `1.0.0-alpha2` branch and updates all documentation and examples to reflect the removal of the leading dot from JSON field paths.

Ref: #345 