### PR TITLE
revise 'component definition' to 'component declaration'

### DIFF
--- a/7.application_configuration.md
+++ b/7.application_configuration.md
@@ -46,7 +46,7 @@ The [Workload](3.workload.md) chapter of the specification defines how schematic
 
 A component can be deployed into numerous different runtimes. However, at runtime there is a one-to-one correspondence between an _instance of a configuration_ and an _application configuration_.
 
-Conceptually speaking, an application configuration is managed as part of the _application operator_ role. An application configuration includes one or more component instances, each represented by a component definition that defines how an instance of a component spec should be deployed. The component definition has three parts:
+Conceptually speaking, an application configuration is managed as part of the _application operator_ role. An application configuration includes one or more component instances, each represented by a component declaration that defines how an instance of a component spec should be deployed. The component declaration has three parts:
   - Overrides of component parameters
   - List of traits, each of which has overrides for that trait's parameters
   - List of application scopes into which the component should be deployed

--- a/7.application_configuration.md
+++ b/7.application_configuration.md
@@ -46,7 +46,7 @@ The [Workload](3.workload.md) chapter of the specification defines how schematic
 
 A component can be deployed into numerous different runtimes. However, at runtime there is a one-to-one correspondence between an _instance of a configuration_ and an _application configuration_.
 
-Conceptually speaking, an application configuration is managed as part of the _application operator_ role. An application configuration includes one or more component instances, each represented by a component declaration that defines how an instance of a component spec should be deployed. The component declaration has three parts:
+Conceptually speaking, an application configuration is managed as part of the _application operator_ role. An application configuration references one or more component instances, each represented by a section that defines how an instance of a component spec should be deployed. In detail, this section has three parts:
   - Overrides of component parameters
   - List of traits, each of which has overrides for that trait's parameters
   - List of application scopes into which the component should be deployed


### PR DESCRIPTION
I think it's more appropriate to say 'component declaration' here.
I thought it was Component Definition itself.