### PR TITLE
Fix mutually exclusive fields and definition sample

### DIFF
--- a/3.component.md
+++ b/3.component.md
@@ -29,10 +29,10 @@ The spec defines the constituent parts of a component.
 
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
-| `type` | string | Y | | The type of workload|
-| `settings` | [`WorkloadSettings`](#workloadsettings) | Y | | The workload-specific configuration. |
-| `parameters` | [`[]Parameter`](#parameter) | N | | The component's configuration options. |
-| `workload` | [`Workload`](#workload) | Y | | <kbd>LEGACY</kbd> The specification of workload that should be passed to the runtime. |
+| `type` | string | N | | The type of workload. |
+| `settings` | [`WorkloadSettings`](#workloadsettings) | N | | The workload-specific configuration. |
+| `parameters` | [`[]Parameter`](#parameter) | N | | The component's configurable parameters. |
+| `workload` | [`Workload`](#workload) | N | | <kbd>LEGACY</kbd> The full specification of workload that should be passed to the runtime. This field is mutually exclusive with `type` and `settings`.|
 
 #### Type
 
@@ -73,10 +73,10 @@ metadata:
   annotations:
     version: v1.0.0
     description: >
-      Sample component that describes the administrative interface for our Twitter bot.
+      Sample component that describes a very cool workload.
 spec:
-  type: Server
-  settings:
+  type: Server # <--- the type of the workload
+  settings: # <---- the settings of the workload
     osType: linux
     containers:
     - name: my-cool-workload
@@ -105,11 +105,11 @@ spec:
   - name: imageName
     required: false
     fieldPaths: 
-    - "spec.containers[0].image"
+    - "settings.containers[0].image"
   - name: cacheSecret
     required: true
     fieldPaths:
-    - "spec.containers[0].env[0].value"
+    - "settings.containers[0].env[0].value"
 ```
 
 > The component above assumes a `WorkloadDefinition` named `Server` exists in the system.

--- a/4.workload_definitions.md
+++ b/4.workload_definitions.md
@@ -25,7 +25,7 @@ The metadata section describes the workload definition. See [*metadata*](2.overv
 
 The `name` of the workload definition indicates _the type of this workload_.
 
-The following workload types are available and enforced by OAM specification:
+The following core workload types are available and enforced by OAM specification:
 
 |Name|Category|Schema|Exposed|Replicable|Daemonized|
 |-|-|-|-|-|-|
@@ -50,7 +50,7 @@ The specification section contains a reference to the workload definition.
 | Attribute | Type | Required | Default Value | Description |
 |-----------|------|----------|---------------|-------------|
 | `definitionRef` | [`DefinitionRef`](#DefinitionRef) | Y | | Workload schema reference. |
-| `extension` | unstructured | N | | <kbd>EXPERIMENTAL</kbd> A unstructured field for the implementation to reuse definition object carry extra information for UI or helper purpose. For example, a markdown description of how to use this workload etc. The implementation should NOT abuse this field for functional purpose. |
+| `extension` | unstructured | N | | <kbd>EXPERIMENTAL</kbd> An unstructured field for the OAM platform builders to carry extra information in the definition objects for UI or helper purposes. For example, this field can contain a markdown description of how to use the workload. The implementation should NOT abuse this field for other purposes. |
 
 #### DefinitionRef
 
@@ -99,10 +99,10 @@ Here is an example of a core workload definition:
 apiVersion: core.oam.dev/v1alpha2
 kind: WorkloadDefinition
 metadata:
-  name: MyWorkloadType
+  name: Server # workload type
 spec:
   definitionRef:
-    name: x.core.oam.dev
+    name: containerizedworkloads.core.oam.dev # workload schema
 ```
 
 All core workload types are container-based, and assume that an implementation is capable of executing an OCI or Docker image as a container, and are capable of working with OCI registries.
@@ -115,10 +115,10 @@ A standard workload schema MUST be in the `standard.oam.dev` group. OAM implemen
 apiVersion: core.oam.dev/v1alpha2
 kind: WorkloadDefinition
 metadata:
-  name: MyWorkloadType
+  name: WebService # workload type
 spec:
   definitionRef:
-    name: x.standard.oam.dev
+    name: podspecworkloads.standard.oam.dev # workload schema
 ```
 
 ### Extended Workload
@@ -131,10 +131,10 @@ Each OAM runtime may define its own workload definition beyond this specificatio
 apiVersion: core.oam.dev/v1alpha2
 kind: WorkloadDefinition
 metadata:
-  name: MyWorkloadType
+  name: Redis # workload type
 spec:
   definitionRef:
-    name: foo.cache.io
+    name: redis.cache.aliyun.com # workload schema
 ```
 
 | Previous      | Next        |

--- a/7.application_configuration.md
+++ b/7.application_configuration.md
@@ -120,7 +120,7 @@ The trait section defines an instance of a trait.
 |-----------|------|----------|---------------|-------------|
 | `name`| string | N | |  The name of trait definition. This is used to reference to the definition/schema of the Trait. For one type of trait, there could be only one config/deploy in one component. |
 | `properties`| [`Properties`](#properties) | N | |  The configurable properties that are exposed by this trait. |
-| `trait`| [`TraitData`](#traitdata) | N | |  <kbd>LEGACY</kbd> The specification of trait that should be passed to the runtime. |
+| `trait`| [`TraitData`](#traitdata) | N | |  <kbd>LEGACY</kbd> The full specification of trait that should be passed to the runtime. This field is mutually exclusive with `name` and `properties`. |
 
 > The `name` field must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ Open Application Model defines a number of standard but extensible abstractions 
 
 ### Why Open Application Model?
 
-For platform builders who create the application platform, OAM provides _Building Block Objects_ with:
+For platform builders who create application platforms:
 - Application level abstractions - building developer facing platforms by default.
 - Extensibility - bring your own abstractions or capabilities.
 - Clarity and manageability - leveraging modularized and re-usable building blocks.
 - No capability lock-in - decoupled abstractions and implementation.
 
-For end users of the OAM based platform, OAM defines _User Interface Objects_ that enable users to:
+For end users of those application platforms:
 - Think applications, not containers or orchestrators.
 - Build modern applications by default.
 - Operation is part of the application lifecycle.

--- a/SPEC.md
+++ b/SPEC.md
@@ -36,7 +36,7 @@ Learn more about versioning [below](#versioning).
 | Route  | standard |  WIP      |
 | Rollout  | standard |   WIP        |
 | Auto Scaler  | standard | WIP        |
-| Monitoring | standard | WIP        |
+| Metrics | standard | WIP        |
 |                               |
 | **Scopes**  |
 | Network Scope  | standard |  [v1alpha2](standard/scopes/network_scope.md)          |

--- a/core/workloads/schema/containerized_workload.md
+++ b/core/workloads/schema/containerized_workload.md
@@ -1,9 +1,8 @@
 # Containerized Workload
 
-The `ContainerizedWorkload` is a generic workload definition which could be referenced as the schema for long-running containerized workload types. 
+The `ContainerizedWorkload` is a **Serverless Container** style workload definition that could be referenced as the schema for long-running containerized workload types for runtime platforms like Azure ACI, AWS Fargate or simple stateless workload of Kubernetes. 
 
-> 
-Note: it's by design that `ContainerizedWorkload` schema is **NOT** equivalent to Kubernetes `PodSpec`. `ContainerizedWorkload` focuses only on developer facing primitives and exposes ports of containers **by default**.
+> Note: it's by design that `ContainerizedWorkload` schema is **NOT** equivalent to Kubernetes Pod specification. As a schema for serverless style workload, `ContainerizedWorkload` intends to focus on developer facing primitives only and be self-contained so developers don't need to define objects like `ConfigMap` or `Secret`. Also, it exposes container ports by default. Thus, if you are looking for a generic workload schema for Kubernetes based PaaS, we'd recommend to check `PodSpecWorkload` specification instead.
 
 Below is the schematic specification for `ContainerizedWorkload`. 
 
@@ -279,4 +278,4 @@ Memory and disk space use the notation for bytes/kilo/mega/giga/tera/peta by jus
 If a `B` is appended after the unit letter, it MUST be ignored. Thus, `5M` and `5MB` are treated as identical. Case is unimportant. `15k` and `15K` MUST be treated as the same value.
 
 ## Containerized Workload JSON schema
-One can also use a [containerized workload schema](containerized_workload_schema.json) to generate a valid component workload.
+For non-Kubernetes runtime implementations, one could use [JSON schema](containerized_workload_schema.json) as valid containerized workload schema.

--- a/core/workloads/server.md
+++ b/core/workloads/server.md
@@ -33,21 +33,20 @@ A Server is a OAM core workload type to define long-running, scalable workloads 
 	metadata:
 	  name: frontend
 	spec:
-	  workload:
-	    type: Server # <--- type of this workload
-	    spec:        # <--- spec template of this workload
-	      osType: linux
-	      containers:
-	      - name: my-cool-workload
-	        image: example/very-cool-workload:0.1.2@sha256:verytrustworthyhash
-	        resources:
-	          cpu:
-	            required: 1.0
-	          memory:
-	            required: 100MB
-	        cmd:
-	        - "bash lscpu"
-	        ports:
-	        - name: http
-	          value: 8080
+	  type: Server # <--- type of this workload
+	  settings:        # <--- spec template of this workload
+	    osType: linux
+	    containers:
+	    - name: my-cool-workload
+	      image: example/very-cool-workload:0.1.2@sha256:verytrustworthyhash
+	      resources:
+	        cpu:
+	          required: 1.0
+	        memory:
+	          required: 100MB
+	      cmd:
+	      - "bash lscpu"
+	      ports:
+	      - name: http
+	        value: 8080
 	```


### PR DESCRIPTION
Fixes: #411 

1. The `workload` section should be mutually exclusive with `type` and `name`.
2. The `WorkloadDefinition` sample should use real workload types instead of fake workload types.