### PR TITLE
Fix links to section 7

### DIFF
--- a/2.overview_and_terminology.md
+++ b/2.overview_and_terminology.md
@@ -30,7 +30,7 @@ The OAM specification represents OAM objects (component definitions, workload de
 
 ### The Structure of a Schematic
 
-Schematics all follow a similar pattern. Top-level attributes indicate the type of schematic, including its group, version, and kind (see above). A `metadata` section provides information about a particular schematic. All schematics defined in this specification use the same `metadata` attributes, as defined below. Finally, a `spec` section provides the _specification_ for the schematic. For example, the `spec` section of a [Trait](6.traits.md) describes the trait itself, while the `spec` section of an [Application](7.application_configuration.md) describes the components and traits that together comprise an application deployment.
+Schematics all follow a similar pattern. Top-level attributes indicate the type of schematic, including its group, version, and kind (see above). A `metadata` section provides information about a particular schematic. All schematics defined in this specification use the same `metadata` attributes, as defined below. Finally, a `spec` section provides the _specification_ for the schematic. For example, the `spec` section of a [Trait](6.traits.md) describes the trait itself, while the `spec` section of an [Application](7.application.md) describes the components and traits that together comprise an application deployment.
 
 The following example of a application exhibits all three of these sections:
 

--- a/3.component_model.md
+++ b/3.component_model.md
@@ -2,7 +2,7 @@
 
 This section defines component model.
 
-Components describe functional units that may be instantiated as part of a larger distributed application. The [`Application`](7.application_configuration.md) section will describe how components are grouped together and how instances of those components are then configured, while this section will focus on component model itself.
+Components describe functional units that may be instantiated as part of a larger distributed application. The [`Application`](7.application.md) section will describe how components are grouped together and how instances of those components are then configured, while this section will focus on component model itself.
 
 ![alt](./assets/modern_app.png)
 

--- a/6.traits.md
+++ b/6.traits.md
@@ -97,4 +97,4 @@ Implementations of an OAM runtime SHOULD make all supported traits discoverable 
 
 | Previous Part | Next Part   |
 | ------------- |-------------|
-| [5. Application Scopes](5.application_scopes.md) | [7. Application](7.application_configuration.md) |
+| [5. Application Scopes](5.application_scopes.md) | [7. Application](7.application.md) |

--- a/7.application.md
+++ b/7.application.md
@@ -141,7 +141,7 @@ In addition, as an application is released, its _workload instances_ (running co
 To accommodate this definition of a release, an OAM platform SHOULD make the following assumptions:
 
 - An application is mutable.
-- Any change to an [application](7.application_configuration.md) results (conceptually) in a new release that supersedes older releases.
+- Any change to an [application](7.application.md) results (conceptually) in a new release that supersedes older releases.
   * If an application is updated, and the new version includes components not present in the original application, component instances MUST be created
   * If an application is updated, and the new version does not have a record of a component that the previous application contained, that component instance MUST be deleted
   * Traits similarly SHOULD be attached and detached according to the same guidelines

--- a/8.practical_considerations.md
+++ b/8.practical_considerations.md
@@ -31,4 +31,4 @@ Other security details, such as network transport security or securing data at r
 
 | Previous      | Next        |
 | ------------- |-------------|
-| [7. Application Configuration](7.application_configuration.md)  | [9. Design Principles](9.design_principles.md) |
+| [7. Application Configuration](7.application.md)  | [9. Design Principles](9.design_principles.md) |


### PR DESCRIPTION
These links referenced the old Application Configuration file name used prior to `v0.3.0`.