### PR TITLE
Fix broken links for Metadata

### DIFF
--- a/3.component_model.md
+++ b/3.component_model.md
@@ -22,7 +22,7 @@ Here are the attributes that provide top-level information about the component d
 |-----------|------|----------|---------------|-------------|
 | `apiVersion` | `string` | Y | | A string that identifies the version of the schema the object should have. The core types uses `core.oam.dev/v1beta1` in this version of model |
 | `kind` | `string` | Y || Must be `ComponentDefinition` |
-| `metadata` | [`Metadata`](2.overview_and_terminology.md#metadata) | Y | | Entity metadata. |
+| `metadata` | [`Metadata`](metadata.md) | Y | | Entity metadata. |
 | `spec`| [`Spec`](#spec) | Y | | The specification for the component definition. |
 
 ### Spec

--- a/4.workload_types.md
+++ b/4.workload_types.md
@@ -16,7 +16,7 @@ Here are the attributes that provide top-level information about the workload de
 |-----------|------|----------|---------------|-------------|
 | `apiVersion` | `string` | Y | | A string that identifies the version of the schema the object should have. The core types uses `core.oam.dev/v1beta1` in this version of model |
 | `kind` | `string` | Y || Must be `WorkloadDefinition` |
-| `metadata` | [`Metadata`](2.overview_and_terminology.md#metadata) | Y | | Entity metadata. |
+| `metadata` | [`Metadata`](metadata.md) | Y | | Entity metadata. |
 | `spec`| [`Spec`](#spec) | Y | | The specification for the workload definition. |
 
 #### Spec

--- a/5.application_scopes.md
+++ b/5.application_scopes.md
@@ -31,7 +31,7 @@ These attributes provide top-level information about the application scope.
 |-----------|------|----------|---------------|-------------|
 | `apiVersion` | `string` | Y || A string that identifies the version of the schema the object should have. The core types uses `core.oam.dev/v1beta1` in this version of model. |
 | `kind` | `string` | Y || Must end with `ScopeDefinition`. |
-| `metadata` | [`Metadata`](2.overview_and_terminology.md#metadata) | Y | | Entity metadata. |
+| `metadata` | [`Metadata`](metadata.md) | Y | | Entity metadata. |
 | `spec`| [`Spec`](#spec) | Y || A specification for scope attributes. |
 
 ### Spec

--- a/6.traits.md
+++ b/6.traits.md
@@ -20,7 +20,7 @@ The top-level attributes of a trait define its metadata, version, kind, and spec
 |-----------|------|----------|---------------|-------------|
 | `apiVersion` | `string` | Y || A string that identifies the version of the schema the object should have. The core types uses `core.oam.dev/v1beta1` in this version of documentation. |
 | `kind` | `string` | Y || Must be `TraitDefinition` |
-| `metadata` | [`Metadata`](2.overview_and_terminology.md#metadata) | Y | | Information about the trait. |
+| `metadata` | [`Metadata`](metadata.md) | Y | | Information about the trait. |
 | `spec`| [`Spec`](#spec) | Y || A specification for trait attributes. |
 
 ### Spec


### PR DESCRIPTION
The original metadata link https://github.com/oam-dev/spec/blob/master/2.overview_and_terminology.md#metadata is broken.
It should be replaced with this link https://github.com/oam-dev/spec/blob/master/metadata.md
