### PR TITLE
Fix operationalConfigurationSpec properties

### DIFF
--- a/schema/application_configuration.schema.json
+++ b/schema/application_configuration.schema.json
@@ -55,25 +55,27 @@
     "additionalProperties": false,
     "definitions": {
         "operationalConfigurationSpec": {
-            "variables": {
-                "type": "array",
-                "description": "Variables that can be referenced in parameter values and properties.",
-                "items": {
-                    "$ref": "#/definitions/opconfigVariable"
-                }
-            },
-            "scopes": {
-                "type": "array",
-                "description": "Application scope definitions.",
-                "items": {
-                    "$ref": "#/definitions/applicationScope"
-                }
-            },
-            "components": {
-                "type": "array",
-                "description": "Component instance definitions.",
-                "items": {
-                    "$ref": "#/definitions/componentInstance"
+            "properties": {
+                "variables": {
+                    "type": "array",
+                    "description": "Variables that can be referenced in parameter values and properties.",
+                    "items": {
+                        "$ref": "#/definitions/opconfigVariable"
+                    }
+                },
+                "scopes": {
+                    "type": "array",
+                    "description": "Application scope definitions.",
+                    "items": {
+                        "$ref": "#/definitions/applicationScope"
+                    }
+                },
+                "components": {
+                    "type": "array",
+                    "description": "Component instance definitions.",
+                    "items": {
+                        "$ref": "#/definitions/componentInstance"
+                    }
                 }
             },
             "required": [],


### PR DESCRIPTION
I wanted to generate code from the schema and noticed that the spec properties were missing.
Also it would probably be better to use this type directly, and not as "additionalProperties" ref.